### PR TITLE
Simplify the frontend landing page

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,215 +1,61 @@
-<script>
-  const stats = [
-    { label: 'Video-aware trimming', value: 'Use EXIF to match GPX start & end' },
-    { label: 'Map animation ready', value: 'Tile-aligned Web Mercator export' },
-    { label: 'Reliable fallbacks', value: 'Uses file mtime when metadata is missing' }
-  ];
-
-  const highlights = [
-    {
-      eyebrow: 'gpx_splitter.py',
-      title: 'Sync video and GPS effortlessly',
-      copy: 'Read creation and duration metadata, trim the track to what the camera actually captured, and export a clean GPX clip.'
-    },
-    {
-      eyebrow: 'map_animator.py',
-      title: 'Render motion with context',
-      copy: 'Convert coordinates to EPSG:3857, fetch OpenStreetMap tiles automatically, and draw a smooth progress line over your route.'
-    },
-    {
-      eyebrow: 'Confidence baked in',
-      title: 'Clear feedback while you work',
-      copy: 'Warnings when timestamps are missing, strong defaults for UTC data, and a simple workflow you can reuse for every ride or hike.'
-    }
-  ];
-
-  const workflow = [
-    {
-      number: '01',
-      title: 'Import your footage + GPX',
-      copy: 'Drop a GoPro (or other camera) MP4 along with the matching GPX track. EXIF metadata guides the crop so your overlay lines up.'
-    },
-    {
-      number: '02',
-      title: 'Crop to the exact clip',
-      copy: 'Run gpx_splitter.py to trim the track to the video start/end. Keep the default output or choose a custom destination path.'
-    },
-    {
-      number: '03',
-      title: 'Animate or export',
-      copy: 'Feed the cropped GPX to map_animator.py to render a basemap animation with ffmpeg, or hand it to your overlay tool of choice.'
-    }
-  ];
-
-  const capabilityCards = [
-    {
-      eyebrow: 'Ready to run',
-      title: 'Install the essentials',
-      copy: 'Use exiftool for metadata, ffmpeg for exports, and Python packages like gpxpy, matplotlib, and contextily for maps.',
-      chips: ['exiftool', 'ffmpeg', 'gpxpy', 'matplotlib', 'contextily']
-    },
-    {
-      eyebrow: 'Data you can trust',
-      title: 'Timezone-aware processing',
-      copy: 'UTC timestamps keep everything aligned. Missing timestamps trigger explicit warnings so you can fix files before exporting.',
-      chips: ['UTC-first', 'Warnings when missing', 'Fallbacks logged']
-    },
-    {
-      eyebrow: 'Output options',
-      title: 'Share-ready results',
-      copy: 'Write cropped GPX files for overlays or render MP4 map animations sized for your project, from social posts to 4K exports.',
-      chips: ['GPX crops', '1920x1080 defaults', 'Custom durations']
-    }
-  ];
-
-  const callouts = [
-    {
-      title: 'Fast iteration',
-      copy: 'Keep your tooling local and repeatable. Swap in new clips without rebuilding the whole workflow.'
-    },
-    {
-      title: 'Clean visual layer',
-      copy: 'Use the map animation as a hero visual, B-roll, or lower-third element—no extra post-processing required.'
-    },
-    {
-      title: 'Works offline',
-      copy: 'Once tiles are cached, you can iterate without a connection and keep exports reproducible.'
-    }
-  ];
-</script>
-
 <svelte:head>
-  <meta name="description" content="Landing page for GPX Helper, the toolkit that syncs GoPro video with GPX tracks and renders map animations." />
+  <meta
+    name="description"
+    content="GPX Helper simplifies syncing GPX tracks with video footage and preparing map-ready exports."
+  />
 </svelte:head>
 
 <main class="page">
   <section class="hero">
-    <div>
-      <div class="hero__badge">GPX Helper · Svelte landing</div>
-      <h1 class="hero__title">Sync footage, trim GPX tracks, and render map animations with clarity.</h1>
-      <p class="hero__copy">
-        A lightweight surface for the GPX_helper toolkit—built to spotlight the Python utilities that align camera
-        footage with GPS data and export ready-to-share visuals.
-      </p>
-
-      <div class="hero__actions">
-        <a class="btn primary" href="#workflow">See the workflow</a>
-        <a
-          class="btn secondary"
-          href="https://github.com/OpenAI-Tools/GPX_helper"
-          target="_blank"
-          rel="noreferrer"
-        >
-          View CLI docs
-        </a>
-      </div>
-
-      <div class="hero__stats">
-        {#each stats as stat}
-          <div class="stat-card">
-            <div class="stat-card__label">{stat.label}</div>
-            <div class="stat-card__value">{stat.value}</div>
-          </div>
-        {/each}
-      </div>
-    </div>
-
-    <div class="hero__visual">
-      <div class="visual-row">
-        <div class="visual-card">
-          <h4>gpx_splitter.py</h4>
-          <p>Read EXIF metadata, trim the track to match the clip, and export a new GPX with precise timestamps.</p>
-        </div>
-        <div class="visual-card">
-          <h4>map_animator.py</h4>
-          <p>Convert to Web Mercator, fetch OSM tiles, and render a smooth MP4 route animation with ffmpeg.</p>
-        </div>
-      </div>
-      <div class="visual-card">
-        <h4>Workflow preview</h4>
-        <p>
-          Import your video and GPX, crop confidently, then animate. The toolkit keeps things tidy with warnings and
-          helpful defaults.
-        </p>
-      </div>
+    <div class="hero__badge">GPX Helper</div>
+    <h1>Make GPX + video sync simple.</h1>
+    <p class="hero__copy">
+      A focused landing page for the GPX_helper toolkit. Trim tracks to footage, prep map-ready exports, and keep your
+      workflow predictable.
+    </p>
+    <div class="hero__actions">
+      <a class="btn primary" href="https://github.com/OpenAI-Tools/GPX_helper" target="_blank" rel="noreferrer">
+        View the toolkit
+      </a>
+      <a class="btn secondary" href="#steps">How it works</a>
     </div>
   </section>
 
-  <div class="section-title" id="workflow">
-    <h2>Your end-to-end path</h2>
-    <p>Three steps to aligned overlays and map-ready exports.</p>
-  </div>
-  <div class="panel timeline">
-    {#each workflow as step}
-      <div class="timeline-step">
-        <div class="bubble">{step.number}</div>
-        <div>
-          <h4>{step.title}</h4>
-          <p>{step.copy}</p>
-        </div>
-      </div>
-    {/each}
-  </div>
+  <section class="panel" id="steps">
+    <h2>Three quick steps</h2>
+    <ol class="steps">
+      <li>
+        <strong>Import footage + GPX.</strong>
+        <span>Point the scripts at your video file and matching track.</span>
+      </li>
+      <li>
+        <strong>Trim with confidence.</strong>
+        <span>Use metadata to crop the GPX to the real clip window.</span>
+      </li>
+      <li>
+        <strong>Export for maps.</strong>
+        <span>Generate a clean GPX or an animation-ready route.</span>
+      </li>
+    </ol>
+  </section>
 
-  <div class="section-title">
-    <h2>What&apos;s inside</h2>
-    <p>Tooling details so you know exactly how the landing connects to the Python scripts.</p>
-  </div>
-  <div class="card-grid">
-    {#each highlights as item}
-      <div class="card">
-        <small>{item.eyebrow}</small>
-        <h3>{item.title}</h3>
-        <p>{item.copy}</p>
-      </div>
-    {/each}
-  </div>
-
-  <div class="section-title">
-    <h2>Capabilities at a glance</h2>
-    <p>Dependencies, safeguards, and export targets in one place.</p>
-  </div>
-  <div class="card-grid">
-    {#each capabilityCards as card}
-      <div class="card">
-        <small>{card.eyebrow}</small>
-        <h3>{card.title}</h3>
-        <p>{card.copy}</p>
-        <div class="chip-row">
-          {#each card.chips as chip}
-            <span class="chip">{chip}</span>
-          {/each}
-        </div>
-      </div>
-    {/each}
-  </div>
-
-  <div class="section-title">
-    <h2>Why this matters</h2>
-    <p>Designed to stay fast, visual, and predictable.</p>
-  </div>
-  <div class="callouts">
-    {#each callouts as callout}
-      <div class="panel callout">
-        <h3>{callout.title}</h3>
-        <p>{callout.copy}</p>
-      </div>
-    {/each}
-  </div>
-
-  <div class="gradient-border footer-cta">
-    <div class="panel footer-cta">
-      <h3>Ready to build your overlay?</h3>
-      <p>
-        Use the landing page as your launchpad: crop GPX to your footage, animate routes, and keep your next ride or hike
-        perfectly in sync.
-      </p>
-      <div class="hero__actions" style="justify-content: center">
-        <a class="btn primary" href="https://github.com/OpenAI-Tools/GPX_helper" target="_blank" rel="noreferrer">
-          Open the toolkit
-        </a>
-        <a class="btn secondary" href="#workflow">Review the steps</a>
-      </div>
+  <section class="panel highlights">
+    <div>
+      <h3>What you get</h3>
+      <p>Lightweight scripts and clear defaults so you can iterate fast.</p>
     </div>
-  </div>
+    <ul>
+      <li>EXIF-backed trim for video alignment.</li>
+      <li>Web Mercator export for map animation workflows.</li>
+      <li>Warnings and fallbacks when timestamps are missing.</li>
+    </ul>
+  </section>
+
+  <section class="footer-cta">
+    <h3>Backend coming next</h3>
+    <p>For now, this stays frontend-only. We can hook it up once the backend is ready.</p>
+    <a class="btn primary" href="https://github.com/OpenAI-Tools/GPX_helper" target="_blank" rel="noreferrer">
+      Read the docs
+    </a>
+  </section>
 </main>

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,14 +1,11 @@
-@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&display=swap');
 
 :root {
   color-scheme: light;
   font-family: 'Inter', system-ui, -apple-system, sans-serif;
-  background: radial-gradient(circle at 20% 20%, #151c39, #0b1021 40%),
-    radial-gradient(circle at 80% 0%, #11192f, transparent 25%),
-    #080b16;
-  color: #e9ecf5;
+  background: radial-gradient(circle at top, #161c34, #0b1021 55%);
+  color: #eef2ff;
   line-height: 1.5;
-  font-weight: 400;
   min-height: 100%;
 }
 
@@ -27,68 +24,54 @@ body {
 }
 
 .page {
-  max-width: 1200px;
+  max-width: 960px;
   margin: 0 auto;
-  padding: 48px 20px 72px;
-}
-
-.gradient-border {
-  position: relative;
-  background: linear-gradient(120deg, rgba(0, 188, 212, 0.35), rgba(124, 77, 255, 0.25));
-  padding: 1px;
-  border-radius: 24px;
-}
-
-.panel {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 22px;
-  padding: 28px;
-  box-shadow: 0 20px 80px rgba(0, 0, 0, 0.25);
-  backdrop-filter: blur(8px);
+  padding: 56px 20px 72px;
+  display: grid;
+  gap: 28px;
 }
 
 .hero {
   display: grid;
-  grid-template-columns: 1.1fr 0.9fr;
-  gap: 24px;
-  align-items: center;
-  margin-bottom: 36px;
+  gap: 16px;
 }
 
 .hero__badge {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  background: rgba(0, 188, 212, 0.16);
-  color: #8be9fd;
+  padding: 6px 12px;
   border-radius: 999px;
-  font-size: 14px;
+  background: rgba(124, 77, 255, 0.2);
+  color: #b8a7ff;
   font-weight: 600;
-  letter-spacing: 0.2px;
-  margin-bottom: 14px;
+  font-size: 13px;
+  letter-spacing: 0.02em;
+  width: fit-content;
 }
 
-.hero__title {
-  font-family: 'Space Grotesk', 'Inter', system-ui, sans-serif;
-  font-size: clamp(28px, 4vw, 44px);
-  margin: 0 0 12px;
+h1 {
+  font-family: 'Space Grotesk', 'Inter', sans-serif;
+  font-size: clamp(32px, 5vw, 48px);
+  margin: 0;
   line-height: 1.1;
-  letter-spacing: -0.02em;
+}
+
+h2,
+h3 {
+  font-family: 'Space Grotesk', 'Inter', sans-serif;
+  margin: 0 0 8px;
 }
 
 .hero__copy {
-  margin: 0 0 20px;
-  color: #c9d3ef;
+  margin: 0;
+  color: #c9d2f4;
   font-size: 18px;
 }
 
 .hero__actions {
   display: flex;
-  gap: 12px;
   flex-wrap: wrap;
-  margin-bottom: 18px;
+  gap: 12px;
 }
 
 .btn {
@@ -96,243 +79,79 @@ body {
   align-items: center;
   justify-content: center;
   padding: 12px 18px;
-  border-radius: 14px;
+  border-radius: 12px;
   font-weight: 600;
-  gap: 8px;
   border: 1px solid transparent;
-  transition: transform 0.15s ease, box-shadow 0.15s ease, border 0.15s ease;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
 .btn.primary {
   background: linear-gradient(120deg, #00bcd4, #7c4dff);
-  color: #0a0f1f;
-  box-shadow: 0 12px 30px rgba(0, 188, 212, 0.28);
+  color: #0c1020;
+  box-shadow: 0 14px 30px rgba(0, 188, 212, 0.25);
 }
 
 .btn.secondary {
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  color: #c9d3ef;
-  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: #d6dcf7;
+  background: rgba(255, 255, 255, 0.04);
 }
 
 .btn:hover {
   transform: translateY(-2px);
-  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.22);
 }
 
-.hero__stats {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 12px;
-}
-
-.stat-card {
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 14px;
-  padding: 14px;
-}
-
-.stat-card__label {
-  color: #9ab0d6;
-  font-size: 13px;
-  margin-bottom: 6px;
-}
-
-.stat-card__value {
-  font-size: 22px;
-  font-weight: 700;
-  font-family: 'Space Grotesk', 'Inter', sans-serif;
-}
-
-.hero__visual {
-  height: 100%;
-  background: linear-gradient(160deg, rgba(0, 188, 212, 0.2), rgba(124, 77, 255, 0.3));
+.panel {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 18px;
-  padding: 18px;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.visual-row {
-  display: flex;
-  gap: 12px;
-}
-
-.visual-card {
-  flex: 1;
-  background: rgba(5, 10, 25, 0.6);
-  border-radius: 14px;
-  padding: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.07);
-}
-
-.visual-card h4 {
-  margin: 0 0 8px;
-  font-size: 15px;
-  color: #8be9fd;
-}
-
-.visual-card p {
-  margin: 0;
-  color: #cfd7f2;
-  font-size: 14px;
-}
-
-.section-title {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin: 46px 0 16px;
-}
-
-.section-title h2 {
-  margin: 0;
-  font-family: 'Space Grotesk', 'Inter', sans-serif;
-  font-size: 26px;
-}
-
-.section-title p {
-  margin: 0;
-  color: #a8b7da;
-}
-
-.card-grid {
+  padding: 24px;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 14px;
 }
 
-.card {
-  background: rgba(255, 255, 255, 0.03);
-  border-radius: 16px;
-  padding: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.07);
+.steps {
+  margin: 0;
+  padding-left: 20px;
   display: grid;
-  gap: 8px;
-}
-
-.card small {
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: #8be9fd;
-  font-weight: 700;
-  font-size: 12px;
-}
-
-.card h3 {
-  margin: 0;
-  font-size: 18px;
-}
-
-.card p {
-  margin: 0;
-  color: #c9d3ef;
-}
-
-.chip-row {
-  display: flex;
-  flex-wrap: wrap;
   gap: 10px;
+  color: #d5def8;
 }
 
-.chip {
-  padding: 8px 12px;
-  border-radius: 999px;
-  background: rgba(0, 188, 212, 0.12);
-  color: #b4e9f7;
-  font-weight: 600;
-  font-size: 13px;
-}
-
-.timeline {
+.steps li {
   display: grid;
+  gap: 4px;
+}
+
+.highlights {
   gap: 12px;
-  margin-top: 12px;
 }
 
-.timeline-step {
-  display: grid;
-  grid-template-columns: 52px 1fr;
-  gap: 12px;
-  align-items: start;
-  padding: 14px;
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 14px;
-}
-
-.bubble {
-  width: 52px;
-  height: 52px;
-  border-radius: 50%;
-  background: radial-gradient(circle at 30% 30%, rgba(124, 77, 255, 0.4), rgba(0, 188, 212, 0.35));
-  display: grid;
-  place-items: center;
-  color: #0b0f1f;
-  font-weight: 800;
-  font-family: 'Space Grotesk', 'Inter', sans-serif;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.timeline h4 {
-  margin: 0 0 4px;
-}
-
-.timeline p {
+.highlights ul {
   margin: 0;
-  color: #c9d3ef;
-}
-
-.callouts {
+  padding-left: 20px;
+  color: #d5def8;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 12px;
-  margin-top: 12px;
-}
-
-.callout {
-  background: rgba(0, 188, 212, 0.08);
-  color: #e9f7fb;
-  border: 1px solid rgba(0, 188, 212, 0.28);
+  gap: 6px;
 }
 
 .footer-cta {
-  margin-top: 40px;
   text-align: center;
-  background: linear-gradient(120deg, rgba(0, 188, 212, 0.16), rgba(124, 77, 255, 0.18));
-  border: 1px solid rgba(255, 255, 255, 0.09);
-}
-
-.footer-cta h3 {
-  margin: 0 0 10px;
-  font-size: 24px;
+  background: linear-gradient(135deg, rgba(0, 188, 212, 0.15), rgba(124, 77, 255, 0.2));
+  border-radius: 20px;
+  padding: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  display: grid;
+  gap: 12px;
 }
 
 .footer-cta p {
-  margin: 0 0 18px;
-  color: #d8e3fa;
-}
-
-@media (max-width: 960px) {
-  .hero {
-    grid-template-columns: 1fr;
-  }
-
-  .hero__visual {
-    order: -1;
-  }
+  margin: 0;
+  color: #d7dff7;
 }
 
 @media (max-width: 640px) {
   .page {
-    padding: 32px 16px 52px;
-  }
-
-  .timeline-step {
-    grid-template-columns: 1fr;
-    text-align: left;
+    padding: 40px 16px 60px;
   }
 }


### PR DESCRIPTION
### Motivation
- Make the landing page minimal and focused so the frontend is easier to extend when the backend is connected later.
- Remove dense, multi-section content and large visual components to improve clarity and maintenance.
- Reduce stylesheet surface area to match the simplified layout and improve responsive behavior.

### Description
- Replace the verbose landing content with a streamlined hero, three-step flow, highlights panel, and a focused CTA in `frontend/src/App.svelte`.
- Remove runtime data arrays and many UI sections (stats, visuals, workflow timeline, capability cards, callouts) and update the page `meta` description.
- Replace the large original stylesheet with a compact, responsive `frontend/src/app.css` that trims unused rules and adapts spacing and typography for a smaller layout.
- Keep links to the repository/docs and leave a note in the UI that backend integration will come next.

### Testing
- Ran `npm install` in `frontend` as an automated step and it failed with a `403 Forbidden` while fetching `@sveltejs/vite-plugin-svelte`, so the app build/dev server could not be verified.
- No other automated tests or build steps were executed due to the dependency fetch failure.
- No unit or integration tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b76f03da883278bb55f11848c50bf)