### PR TITLE
Refine frontend page title to 'SyncTrack Video+GPS Studio'

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>GPX Helper – Sync video & GPS data</title>
+    <title>SyncTrack Video+GPS Studio</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>


### PR DESCRIPTION
### Motivation
- Make the frontend page title more brand-like and better reflect the combined video and GPS synchronization functionality.
- Provide a concise, memorable name that mixes words to convey the app purpose.
- Improve browser tab readability and user recognition.

### Description
- Updated the `frontend/index.html` `<title>` from `GPX Helper – Sync video & GPS data` to `SyncTrack Video+GPS Studio`.
- The change is a single-line edit inside the HTML head.`
- No other files were modified.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c2820582c83279896945b4c46ee36)