### PR TITLE
Restyle frontend to minimal Google-inspired theme

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,11 +1,11 @@
-@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
 
 :root {
   color-scheme: light;
-  font-family: 'Inter', system-ui, -apple-system, sans-serif;
-  background: radial-gradient(circle at top, #161c34, #0b1021 55%);
-  color: #eef2ff;
-  line-height: 1.5;
+  font-family: 'Roboto', system-ui, -apple-system, sans-serif;
+  background-color: #f8f9fa;
+  color: #202124;
+  line-height: 1.6;
   min-height: 100%;
 }
 
@@ -21,50 +21,51 @@ a {
 body {
   margin: 0;
   min-height: 100vh;
+  background-color: #f8f9fa;
 }
 
 .page {
-  max-width: 960px;
+  max-width: 920px;
   margin: 0 auto;
-  padding: 56px 20px 72px;
+  padding: 64px 20px 80px;
   display: grid;
-  gap: 28px;
+  gap: 32px;
 }
 
 .hero {
   display: grid;
-  gap: 16px;
+  gap: 18px;
 }
 
 .hero__badge {
   display: inline-flex;
   align-items: center;
-  padding: 6px 12px;
+  padding: 6px 14px;
   border-radius: 999px;
-  background: rgba(124, 77, 255, 0.2);
-  color: #b8a7ff;
-  font-weight: 600;
+  background: #e8f0fe;
+  color: #1967d2;
+  font-weight: 500;
   font-size: 13px;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.01em;
   width: fit-content;
 }
 
 h1 {
-  font-family: 'Space Grotesk', 'Inter', sans-serif;
-  font-size: clamp(32px, 5vw, 48px);
+  font-size: clamp(30px, 4vw, 44px);
   margin: 0;
-  line-height: 1.1;
+  line-height: 1.2;
+  font-weight: 500;
 }
 
 h2,
 h3 {
-  font-family: 'Space Grotesk', 'Inter', sans-serif;
   margin: 0 0 8px;
+  font-weight: 500;
 }
 
 .hero__copy {
   margin: 0;
-  color: #c9d2f4;
+  color: #5f6368;
   font-size: 18px;
 }
 
@@ -78,36 +79,37 @@ h3 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 12px 18px;
-  border-radius: 12px;
-  font-weight: 600;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 500;
   border: 1px solid transparent;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  transition: background-color 0.15s ease, box-shadow 0.15s ease, color 0.15s ease;
 }
 
 .btn.primary {
-  background: linear-gradient(120deg, #00bcd4, #7c4dff);
-  color: #0c1020;
-  box-shadow: 0 14px 30px rgba(0, 188, 212, 0.25);
+  background: #1a73e8;
+  color: #fff;
+  box-shadow: 0 6px 14px rgba(26, 115, 232, 0.25);
 }
 
 .btn.secondary {
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  color: #d6dcf7;
-  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid #dadce0;
+  color: #1a73e8;
+  background: #fff;
 }
 
 .btn:hover {
-  transform: translateY(-2px);
+  box-shadow: 0 10px 20px rgba(60, 64, 67, 0.15);
 }
 
 .panel {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 18px;
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 16px;
   padding: 24px;
   display: grid;
   gap: 14px;
+  box-shadow: 0 1px 2px rgba(60, 64, 67, 0.08);
 }
 
 .steps {
@@ -115,7 +117,7 @@ h3 {
   padding-left: 20px;
   display: grid;
   gap: 10px;
-  color: #d5def8;
+  color: #5f6368;
 }
 
 .steps li {
@@ -130,28 +132,29 @@ h3 {
 .highlights ul {
   margin: 0;
   padding-left: 20px;
-  color: #d5def8;
+  color: #5f6368;
   display: grid;
   gap: 6px;
 }
 
 .footer-cta {
   text-align: center;
-  background: linear-gradient(135deg, rgba(0, 188, 212, 0.15), rgba(124, 77, 255, 0.2));
-  border-radius: 20px;
+  background: #fff;
+  border-radius: 16px;
   padding: 28px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid #e0e0e0;
   display: grid;
   gap: 12px;
+  box-shadow: 0 1px 2px rgba(60, 64, 67, 0.08);
 }
 
 .footer-cta p {
   margin: 0;
-  color: #d7dff7;
+  color: #5f6368;
 }
 
 @media (max-width: 640px) {
   .page {
-    padding: 40px 16px 60px;
+    padding: 44px 16px 60px;
   }
 }


### PR DESCRIPTION
### Motivation
- Move the landing page from a dark, gradient look to a bright, minimal Google-inspired theme for improved readability and a cleaner aesthetic.
- Use a common system font stack and `Roboto` for consistent typography across platforms.
- Simplify visual surfaces and controls to make the UI feel lighter and more approachable.

### Description
- Replaced font import and base font family by updating `@import` to Roboto and switching the root `font-family` in `frontend/src/app.css`.
- Converted the dark radial background to a light neutral background and updated the global color tokens and spacing for a minimal palette.
- Restyled buttons, panels, badges, and text colors to use light surfaces, subtle shadows, and rounded pill buttons for a Google-like look.
- Adjusted layout spacing and small typographic rules (line-height, font-weight, sizes) in `frontend/src/app.css` to improve visual rhythm.

### Testing
- Started the dev server with `npm run dev` and Vite reported ready, which succeeded. 
- Ran a Playwright script to render the page and capture a screenshot to `artifacts/gpx-helper-minimal.png`, which completed successfully.
- No unit or integration test suites were executed for this style-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c295227a88327a55763058112b3c4)