### PR TITLE
Add scroll offset for sticky header anchors

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -7,10 +7,16 @@
   color: #202124;
   line-height: 1.6;
   min-height: 100%;
+  --header-offset: 96px;
+  scroll-padding-top: var(--header-offset);
 }
 
 * {
   box-sizing: border-box;
+}
+
+[id] {
+  scroll-margin-top: var(--header-offset);
 }
 
 a {


### PR DESCRIPTION
### Motivation
- The site header is `position: sticky` at the top and can cover section headings when navigating to hash anchors.
- Clicking in-page links like `#home`, `#steps`, or `#about` currently scrolls the target to the very top of the viewport and hides the heading under the header.
- A shared offset and scroll-padding/margin makes in-page navigation land content below the header so headings remain visible.

### Description
- Add a `--header-offset` variable in `:root` and set `scroll-padding-top: var(--header-offset)` to offset the scrolling container.
- Add a global rule `[id] { scroll-margin-top: var(--header-offset); }` so anchored sections are offset from the sticky header.
- Change is implemented in `frontend/src/app.css` and applies to all elements with an `id` attribute.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c2cb760f4832791126ba640cd3146)