### PR TITLE
Refine About section copy for brevity and clarity

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -51,12 +51,12 @@
     <section class="panel highlights" id="about">
       <div>
         <h2>About GPX Helper</h2>
-        <p>Built for creators who need clean tracks fast without extra tooling.</p>
+        <p>GPX Helper trims and exports tracks so video projects stay in sync.</p>
       </div>
       <ul>
-        <li>Automated alignment between footage and GPX timestamps.</li>
-        <li>Friendly defaults with clear logging for edge cases.</li>
-        <li>Exports that drop into mapping or editing workflows.</li>
+        <li>Align GPX with footage timestamps.</li>
+        <li>Trim confidently with clear logs.</li>
+        <li>Export routes ready for maps or edits.</li>
       </ul>
     </section>
 


### PR DESCRIPTION
### Motivation
- Make the site About section more concise and product-focused to improve clarity for visitors.
- Emphasize core capabilities (alignment, trimming, export) in shorter, action-oriented lines.
- Keep the landing copy consistent with the toolkit's purpose of syncing GPX and video.

### Description
- Updated the About panel copy in `frontend/src/App.svelte` to a shorter lead sentence.
- Rewrote the three About bullet items to be more direct and actionable.
- Change is content-only and limited to the frontend markup.

### Testing
- Started the dev server with `npm run dev` and the Vite server reported ready (succeeded).
- Loaded the landing page with Playwright and captured a full-page screenshot (succeeded).
- No unit or integration tests were run for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c5c863c888327bcfac657406565df)