### PR TITLE
Add backend README, API tests, and httpx dev dependency

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,41 @@
+# GPX Helper Backend
+
+This backend is a FastAPI service that exposes endpoints for working with GPX files.
+It accepts GPX uploads and trims the track data based on a requested time range or
+based on timestamps extracted from a companion video file.
+
+## How it works
+
+The API is implemented in `backend/src/gpx_helper/api/main.py` and exposes:
+
+- `GET /api/v1/health` for a basic service check.
+- `GET /api/v1/capabilities` to describe available endpoints.
+- `POST /api/v1/gpx/trim-by-time` to crop a GPX file to a provided time range.
+- `POST /api/v1/gpx/trim-by-video` to crop a GPX file based on the time range
+  extracted from an uploaded video.
+
+GPX trimming logic lives in `backend/src/gpx_helper/gpx_splitter.py`.
+The trim-by-video endpoint uses `get_video_times`, which reads video metadata via
+`exiftool` if it is available, then falls back to the file modification time.
+
+## Running the API locally
+
+Install dependencies with Poetry and run the app with Uvicorn:
+
+```bash
+cd backend
+poetry install
+poetry run uvicorn gpx_helper.api.main:app --reload
+```
+
+The API will be available at `http://localhost:8000`.
+
+## Running unit tests
+
+The backend unit tests are located in `backend/tests`.
+Run them from the `backend` directory:
+
+```bash
+cd backend
+poetry run python -m unittest
+```

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,6 +15,9 @@ fastapi = "^0.115.0"
 uvicorn = "^0.30.0"
 python-multipart = "^0.0.9"
 
+[tool.poetry.group.dev.dependencies]
+httpx = "^0.27.2"
+
 
 [build-system]
 requires = ["poetry-core"]

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from io import BytesIO
+import unittest
+from unittest import mock
+import xml.etree.ElementTree as ET
+
+from fastapi.testclient import TestClient
+
+from gpx_helper.api.main import app
+
+
+GPX_NS = "http://www.topografix.com/GPX/1/1"
+
+
+def _build_gpx() -> bytes:
+    return (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<gpx version=\"1.1\" creator=\"test\" xmlns=\"http://www.topografix.com/GPX/1/1\">"
+        "<trk><trkseg>"
+        "<trkpt lat=\"0\" lon=\"0\"><time>2024-01-01T00:00:00Z</time></trkpt>"
+        "<trkpt lat=\"0\" lon=\"0\"><time>2024-01-01T00:00:10Z</time></trkpt>"
+        "<trkpt lat=\"0\" lon=\"0\"><time>2024-01-01T00:00:20Z</time></trkpt>"
+        "</trkseg></trk></gpx>"
+    ).encode("utf-8")
+
+
+def _count_trkpts(payload: bytes) -> int:
+    root = ET.fromstring(payload)
+    return len(root.findall(".//{%s}trkpt" % GPX_NS))
+
+
+class ApiTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.client = TestClient(app)
+
+    def test_health_check(self) -> None:
+        response = self.client.get("/api/v1/health")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok", "service": "gpx-helper"})
+
+    def test_capabilities(self) -> None:
+        response = self.client.get("/api/v1/capabilities")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["version"], "v1")
+        self.assertIn("POST /api/v1/gpx/trim-by-time", payload["endpoints"])
+        self.assertIn("POST /api/v1/gpx/trim-by-video", payload["endpoints"])
+
+    def test_trim_by_time_success(self) -> None:
+        files = {
+            "gpx_file": ("track.gpx", _build_gpx(), "application/gpx+xml"),
+        }
+        data = {
+            "start_time": "2024-01-01T00:00:02Z",
+            "end_time": "2024-01-01T00:00:12Z",
+        }
+
+        response = self.client.post("/api/v1/gpx/trim-by-time", files=files, data=data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "application/gpx+xml")
+        self.assertEqual(_count_trkpts(response.content), 2)
+
+    def test_trim_by_time_invalid_datetime(self) -> None:
+        files = {
+            "gpx_file": ("track.gpx", _build_gpx(), "application/gpx+xml"),
+        }
+        data = {
+            "start_time": "2024-01-01T00:00:02",
+            "end_time": "2024-01-01T00:00:12Z",
+        }
+
+        response = self.client.post("/api/v1/gpx/trim-by-time", files=files, data=data)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("timezone", response.json()["detail"])
+
+    def test_trim_by_time_missing_filename(self) -> None:
+        files = {
+            "gpx_file": ("", _build_gpx(), "application/gpx+xml"),
+        }
+        data = {
+            "start_time": "2024-01-01T00:00:02Z",
+            "end_time": "2024-01-01T00:00:12Z",
+        }
+
+        response = self.client.post("/api/v1/gpx/trim-by-time", files=files, data=data)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["detail"], "Missing gpx_file filename")
+
+    def test_trim_by_video_success(self) -> None:
+        files = {
+            "gpx_file": ("track.gpx", _build_gpx(), "application/gpx+xml"),
+            "video_file": ("clip.mp4", BytesIO(b"fake-video"), "video/mp4"),
+        }
+        start_dt = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        end_dt = datetime(2024, 1, 1, 0, 0, 20, tzinfo=timezone.utc)
+
+        with mock.patch("gpx_helper.api.main.get_video_times", return_value=(start_dt, end_dt)):
+            response = self.client.post("/api/v1/gpx/trim-by-video", files=files)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "application/gpx+xml")
+        self.assertEqual(_count_trkpts(response.content), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide developer-facing documentation for the backend service so contributors can understand and run it locally.
- Add automated API tests to validate the FastAPI endpoints and trimming behavior.
- Ensure the TestClient runtime dependency is declared so tests can run in CI by adding `httpx` as a dev dependency.

### Description
- Add `backend/README.md` describing service purpose, endpoints, and local run/test instructions.
- Add `backend/tests/test_api.py` with unit tests for `GET /api/v1/health`, `GET /api/v1/capabilities`, `POST /api/v1/gpx/trim-by-time`, and `POST /api/v1/gpx/trim-by-video` using `fastapi.testclient.TestClient` and mocking `get_video_times`.
- Update `backend/pyproject.toml` to include `[tool.poetry.group.dev.dependencies]` with `httpx = "^0.27.2"` for TestClient support.
- Tests exercise content-type, status codes, payload validation, and GPX point counting logic.

### Testing
- An attempt to resolve dependencies with `cd backend && poetry lock` was performed and failed due to inability to reach `pypi.org` in this environment.
- No automated unit tests (`poetry run python -m unittest`) were executed in this environment due to the dependency resolution failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d93a2db3c8327833e8f28d8acfa08)