### PR TITLE
Add tests package marker for unittest discovery

### DIFF
--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for gpx_helper backend."""


### PR DESCRIPTION
### Motivation

- Ensure Python's `unittest` test discovery finds the backend tests package.
- Tests in `backend/tests` were not discovered because the package marker file was missing.

### Description

- Add `backend/tests/__init__.py` containing a short module docstring to mark the tests directory as a package.
- No functional code changes to the application or tests were made.

### Testing

- Ran `poetry run python -m unittest` at the repository root and initially observed `Ran 0 tests` prior to the change.
- After adding `backend/tests/__init__.py`, running `poetry run python -m unittest` in the backend triggered test discovery (attempted to load `tests.test_api`).
- Test run failed during import with `ModuleNotFoundError: No module named 'fastapi'`, indicating missing test dependencies in the execution environment.
- No application-level or unit test assertions were executed successfully due to the missing dependency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d9933edd48327acf1aff53b013b88)