### PR TITLE
Handle missing upload filenames gracefully

### DIFF
--- a/backend/src/gpx_helper/api/main.py
+++ b/backend/src/gpx_helper/api/main.py
@@ -37,8 +37,8 @@ def _parse_iso_datetime(value: str) -> datetime:
     return dt.astimezone(timezone.utc)
 
 
-def _validate_upload(upload: UploadFile, label: str) -> None:
-    if not upload.filename:
+def _validate_upload(upload: UploadFile | None, label: str) -> None:
+    if upload is None or not upload.filename:
         raise HTTPException(status_code=400, detail=f"Missing {label} filename")
 
 
@@ -82,7 +82,7 @@ def capabilities() -> JSONResponse:
 
 @app.post("/api/v1/gpx/trim-by-time")
 def trim_by_time(
-    gpx_file: UploadFile = File(...),
+    gpx_file: UploadFile | None = File(None),
     start_time: str = Form(...),
     end_time: str = Form(...),
 ) -> StreamingResponse:
@@ -108,8 +108,8 @@ def trim_by_time(
 
 @app.post("/api/v1/gpx/trim-by-video")
 def trim_by_video(
-    gpx_file: UploadFile = File(...),
-    video_file: UploadFile = File(...),
+    gpx_file: UploadFile | None = File(None),
+    video_file: UploadFile | None = File(None),
 ) -> StreamingResponse:
     _validate_upload(gpx_file, "gpx_file")
     _validate_upload(video_file, "video_file")


### PR DESCRIPTION
### Motivation
- Ensure API endpoints return a 400 error when an uploaded file is missing or has no filename instead of producing a FastAPI validation error.
- Make file parameters optional at the framework level so custom validation can produce consistent error messages.

### Description
- Updated `_validate_upload` to accept `UploadFile | None` and to raise `HTTPException(status_code=400)` when the upload is `None` or has no filename.
- Changed endpoint parameters to be optional (`gpx_file: UploadFile | None = File(None)` and `video_file: UploadFile | None = File(None)`) so FastAPI does not preemptively return a 422.
- Preserved existing behavior for empty file contents by keeping `_write_upload_to_file` checks unchanged.

### Testing
- Before the change `poetry run python -m unittest` ran 6 tests and reported 1 failure where the endpoint returned `422` instead of the expected `400`.
- After the change `poetry run python -m unittest` was executed but tests errored due to a missing dependency (`ModuleNotFoundError: No module named 'fastapi'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d99dbab188327b2538b084fa38584)