### PR TITLE
Add Vitest + Testing Library setup, basic App unit test, and frontend README

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,38 @@
+# GPX Helper Frontend
+
+## Prerequisites
+
+- Node.js 18+
+- npm
+
+## Install
+
+```sh
+npm install
+```
+
+## Run the dev server
+
+```sh
+npm run dev
+```
+
+The app will be available at <http://localhost:4173>.
+
+## Build for production
+
+```sh
+npm run build
+```
+
+## Run tests
+
+```sh
+npm run test
+```
+
+## Run tests in watch mode
+
+```sh
+npm run test:watch
+```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,14 +7,20 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-check --tsconfig ./tsconfig.json"
+    "check": "svelte-check --tsconfig ./tsconfig.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^3.1.2",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/svelte": "^4.2.2",
+    "jsdom": "^24.0.0",
     "svelte": "^4.2.19",
     "svelte-check": "^3.6.9",
     "tslib": "^2.6.2",
     "typescript": "^5.4.0",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "vitest": "^1.2.0"
   }
 }

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/svelte';
+import App from './App.svelte';
+
+describe('App', () => {
+  it('renders the hero headline', () => {
+    render(App);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Make GPX + video sync simple.');
+  });
+});

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,6 +3,11 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 
 export default defineConfig({
   plugins: [svelte()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/setupTests.js'
+  },
   server: {
     host: true,
     port: 4173


### PR DESCRIPTION
### Motivation

- Provide a unit test scaffold for the Svelte frontend so component behavior can be validated automatically.
- Make it easy for contributors to run and develop the frontend by documenting install, run and test commands.

### Description

- Update `frontend/package.json` to add `test` and `test:watch` scripts and new dev dependencies (`vitest`, `@testing-library/svelte`, `@testing-library/jest-dom`, `jsdom`).
- Configure Vitest in `frontend/vite.config.js` to use the `jsdom` environment with `globals` and a `setupFiles` path of `./src/setupTests.js`.
- Add `frontend/src/setupTests.js` to register `@testing-library/jest-dom/vitest` and `frontend/src/App.test.js` with a basic test that asserts the main headline renders.
- Add `frontend/README.md` with instructions for `npm install`, running the dev server (`npm run dev`), building (`npm run build`), and running tests (`npm run test`, `npm run test:watch`).

### Testing

- Attempted to install dependencies with `npm install`, but the install failed due to a registry access policy returning `403 Forbidden` so dependencies were not installed.
- No automated tests were executed because dependency installation was blocked by the registry error.
- Local file-level checks were performed (files added: `src/App.test.js`, `src/setupTests.js`, `README.md`, `package.json`, `vite.config.js`).
- Once dependencies can be installed, tests can be run with `npm run test` (non-watch) and `npm run test:watch` (watch mode).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eef0959dc8327a7c71a95c1bfe91d)