### PR TITLE
Remove API health and capabilities panels from UI

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -178,7 +178,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -202,7 +201,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -971,7 +969,6 @@
       "integrity": "sha512-Txsm1tJvtiYeLUVRNqxZGKR/mI+CzuIQuc2gn+YCs9rMTowpNZ2Nqt53JdL8KF9bLhAf2ruR/dr9eZCwdTriRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^2.1.0",
         "debug": "^4.3.4",
@@ -2778,7 +2775,6 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -3327,7 +3323,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3856,7 +3851,6 @@
       "integrity": "sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -4073,7 +4067,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4116,7 +4109,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",


### PR DESCRIPTION
### Motivation
- Remove the runtime API health/capabilities polling and UI because the app should no longer surface those diagnostics.
- Simplify the hero area and remove the API connection card to keep the interface focused on GPX trim and animation tools.
- Decouple the trim and animation tools from the health/capability state so they render independently.

### Description
- Dropped health/capabilities state (`healthStatus`, `healthMessage`, `capabilities`, `apiVersion`, `capabilitiesError`) and the `refreshApiStatus` logic from `frontend/src/App.svelte`.
- Removed the `onMount`-based refresh and the `apiBaseInput` form binding, and eliminated the API connection card and hero status bar elements that displayed health information.
- Removed the "Available API routes" panel and related `Refresh`/`Re-check` buttons, and simplified `statusTone` so component statuses still compute correctly.
- Updated frontend dependency metadata by running `npm install` which updated `frontend/package-lock.json`.

### Testing
- Ran `npm install` in `frontend` and the install completed successfully.
- Started the dev server with `npm run dev` and Vite reported ready, indicating the app builds and serves.
- Ran a Playwright script that navigated to the served page and produced a full-page screenshot, confirming the UI renders; the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f0f1233f8832798088ac7f58ba2d4)