### PR TITLE
Simplify GPX Helper UI layout and styling

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -255,13 +255,6 @@
     }
   }
 
-  function statusTone(state) {
-    if (state === 'success') return 'positive';
-    if (state === 'loading') return 'info';
-    if (state === 'warning') return 'warning';
-    if (state === 'error') return 'danger';
-    return 'muted';
-  }
 </script>
 
 <svelte:head>
@@ -273,35 +266,21 @@
 
 <div class="page-shell">
   <header class="hero">
-    <div class="hero__copy">
-      <p class="pill">GPX Helper</p>
-      <h1>Run the GPX Helper API from the browser.</h1>
-      <p class="lede">
-        Upload a GPX track, pair it with video metadata, and export trimmed tracks or map animations without leaving the
-        page.
-      </p>
-    </div>
+    <h1>Run the GPX Helper API from the browser.</h1>
+    <p class="lede">
+      Upload a GPX track, pair it with video metadata, and export trimmed tracks or map animations without leaving the
+      page.
+    </p>
   </header>
 
   <main class="content">
     <section class="tool-grid">
       <article class="tool-card">
-        <div class="panel__header">
-          <div>
-            <p class="eyebrow">Trim by timestamps</p>
-            <h3>Trim GPX by time window</h3>
-            <p class="muted-text">Send your GPX file with start and end times to crop the track.</p>
-          </div>
-          <span class={`chip ${statusTone(trimByTime.status)}`}>
-            {trimByTime.status === 'idle'
-              ? 'Waiting'
-              : trimByTime.status === 'loading'
-                ? 'Processing...'
-                : trimByTime.status === 'success'
-                  ? 'Done'
-                  : 'Needs attention'}
-          </span>
-        </div>
+        <header class="section-header">
+          <p class="section-label">Trim by timestamps</p>
+          <h2>Trim GPX by time window</h2>
+          <p class="muted-text">Send your GPX file with start and end times to crop the track.</p>
+        </header>
 
         <form class="form-grid" on:submit|preventDefault={submitTrimByTime}>
           <label>
@@ -339,22 +318,11 @@
       </article>
 
       <article class="tool-card">
-        <div class="panel__header">
-          <div>
-            <p class="eyebrow">Video-assisted trim</p>
-            <h3>Trim GPX using video</h3>
-            <p class="muted-text">Upload the GPX and companion video to crop the track to the clip duration.</p>
-          </div>
-          <span class={`chip ${statusTone(trimByVideo.status)}`}>
-            {trimByVideo.status === 'idle'
-              ? 'Waiting'
-              : trimByVideo.status === 'loading'
-                ? 'Processing...'
-                : trimByVideo.status === 'success'
-                  ? 'Done'
-                  : 'Needs attention'}
-          </span>
-        </div>
+        <header class="section-header">
+          <p class="section-label">Video-assisted trim</p>
+          <h2>Trim GPX using video</h2>
+          <p class="muted-text">Upload the GPX and companion video to crop the track to the clip duration.</p>
+        </header>
 
         <form class="form-grid" on:submit|preventDefault={submitTrimByVideo}>
           <label>
@@ -395,22 +363,11 @@
     </section>
 
     <section class="tool-card wide">
-      <div class="panel__header">
-        <div>
-          <p class="eyebrow">Route animation</p>
-          <h3>Render map animation</h3>
-          <p class="muted-text">Send your GPX to the API to render an MP4 route animation.</p>
-        </div>
-        <span class={`chip ${statusTone(mapAnimation.status)}`}>
-          {mapAnimation.status === 'idle'
-            ? 'Waiting'
-            : mapAnimation.status === 'loading'
-              ? 'Processing...'
-              : mapAnimation.status === 'success'
-                ? 'Done'
-                : 'Needs attention'}
-        </span>
-      </div>
+      <header class="section-header">
+        <p class="section-label">Route animation</p>
+        <h2>Render map animation</h2>
+        <p class="muted-text">Send your GPX to the API to render an MP4 route animation.</p>
+      </header>
 
       <form class="form-grid" on:submit|preventDefault={submitMapAnimation}>
         <label>

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -3,8 +3,8 @@
 :root {
   font-family: 'Space Grotesk', 'Segoe UI', system-ui, sans-serif;
   line-height: 1.6;
-  color: #0f172a;
-  background-color: #050912;
+  color: #111827;
+  background-color: #f5f5f4;
 }
 
 * {
@@ -14,8 +14,8 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(100% 120% at 20% 10%, #12326b 0%, #0a132b 50%, #050912 100%);
-  color: #0f172a;
+  background: #f5f5f4;
+  color: #111827;
 }
 
 a {
@@ -29,128 +29,66 @@ a {
   padding: 32px 18px 72px;
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 20px;
 }
 
 .hero {
   display: grid;
-  grid-template-columns: minmax(0, 2fr) minmax(320px, 1fr);
-  gap: 20px;
-  background: linear-gradient(135deg, #0f1e43 0%, #0a1235 65%, #0c1f4d 100%);
-  border-radius: 20px;
-  padding: 28px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 20px 50px rgba(7, 13, 38, 0.7);
-  color: #f5f7ff;
+  gap: 12px;
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 24px;
+  border: 1px solid #e5e7eb;
 }
 
-.hero__copy h1 {
-  margin: 10px 0 10px;
+.hero h1 {
+  margin: 0;
   font-size: clamp(28px, 4vw, 40px);
-  line-height: 1.15;
+  line-height: 1.2;
   font-weight: 600;
-}
-
-.pill {
-  display: inline-flex;
-  align-items: center;
-  padding: 6px 14px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.12);
-  color: #c4d4ff;
-  font-weight: 600;
-  letter-spacing: 0.02em;
 }
 
 .lede {
-  margin: 0 0 16px;
-  color: #d6def7;
+  margin: 0;
+  color: #4b5563;
   max-width: 620px;
 }
 
-.status-bar {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.chip {
-  display: inline-flex;
-  align-items: center;
-  padding: 6px 12px;
-  border-radius: 999px;
-  font-size: 13px;
-  font-weight: 600;
-  background: rgba(255, 255, 255, 0.15);
-  color: #f5f7ff;
-}
-
-.chip.muted {
-  background: rgba(255, 255, 255, 0.08);
-  color: #d9e1ff;
-}
-
-.chip.positive {
-  background: rgba(71, 191, 133, 0.18);
-  color: #d5f7e7;
-}
-
-.chip.info {
-  background: rgba(96, 165, 250, 0.2);
-  color: #d8e9ff;
-}
-
-.chip.warning {
-  background: rgba(251, 191, 36, 0.2);
-  color: #fef3c7;
-}
-
-.chip.danger {
-  background: rgba(248, 113, 113, 0.2);
-  color: #fee2e2;
-}
-
 .api-card {
-  background: #0d142b;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
   border-radius: 16px;
   padding: 18px;
   display: grid;
   gap: 10px;
-  color: #e6edff;
+  color: #111827;
 }
 
 .api-card label {
   font-weight: 600;
-  color: #d9e1ff;
+  color: #1f2937;
 }
 
 .api-card input {
   width: 100%;
   padding: 10px 12px;
   border-radius: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  background: rgba(255, 255, 255, 0.06);
-  color: #f5f7ff;
+  border: 1px solid #d1d5db;
+  background: #f9fafb;
+  color: #111827;
 }
 
 .api-card input::placeholder {
-  color: #b5c2e8;
+  color: #9ca3af;
 }
 
-.api-card__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.eyebrow {
+.section-label {
   margin: 0;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 12px;
   font-weight: 700;
-  color: #9ab2ff;
+  color: #6b7280;
 }
 
 .input-row {
@@ -160,42 +98,38 @@ a {
 }
 
 button {
-  border: none;
-  border-radius: 12px;
-  background: linear-gradient(135deg, #6ae3b4, #3ec0ff);
-  color: #0b1225;
+  border: 1px solid #111827;
+  border-radius: 10px;
+  background: #111827;
+  color: #ffffff;
   font-weight: 700;
-  padding: 10px 16px;
+  padding: 10px 18px;
   cursor: pointer;
-  transition: transform 0.1s ease, box-shadow 0.15s ease;
-  box-shadow: 0 10px 30px rgba(58, 199, 255, 0.35);
+  transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 button:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 14px 36px rgba(58, 199, 255, 0.45);
+  background: #1f2937;
 }
 
 button:active {
-  transform: translateY(0);
+  background: #0f172a;
 }
 
 .ghost {
   background: transparent;
-  color: inherit;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  box-shadow: none;
+  color: #111827;
+  border: 1px solid #d1d5db;
   padding: 8px 12px;
 }
 
 .ghost:hover {
-  border-color: rgba(255, 255, 255, 0.4);
-  transform: none;
+  border-color: #9ca3af;
 }
 
 .hint {
   margin: 0;
-  color: #b8c5e5;
+  color: #6b7280;
   font-size: 13px;
 }
 
@@ -216,21 +150,17 @@ button:active {
   border-radius: 16px;
   padding: 20px;
   border: 1px solid #e5e7eb;
-  box-shadow: 0 10px 28px rgba(17, 24, 39, 0.08);
   display: grid;
   gap: 12px;
 }
 
-.panel__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
+.section-header {
+  display: grid;
+  gap: 4px;
 }
 
-.panel__header h2,
-.panel__header h3 {
-  margin: 4px 0;
+.section-header h2 {
+  margin: 0;
 }
 
 .endpoint-list {
@@ -275,7 +205,7 @@ select {
 
 input:focus,
 select:focus {
-  outline: 2px solid #3ec0ff;
+  outline: 2px solid #111827;
   outline-offset: 1px;
   background: #fff;
 }
@@ -306,15 +236,15 @@ select:focus {
   align-items: center;
   gap: 8px;
   padding: 10px 14px;
-  border-radius: 12px;
-  background: #0f172a;
-  color: #e5edff;
+  border-radius: 10px;
+  background: #111827;
+  color: #f9fafb;
   font-weight: 700;
   width: fit-content;
 }
 
 .download:hover {
-  background: #111c33;
+  background: #1f2937;
 }
 
 .tool-card.wide {
@@ -327,9 +257,9 @@ select:focus {
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 12px;
-  color: #e6edff;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: #374151;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
   border-radius: 14px;
   padding: 16px 18px;
 }
@@ -339,8 +269,8 @@ select:focus {
 }
 
 @media (max-width: 860px) {
-  .hero {
-    grid-template-columns: 1fr;
+  .page-shell {
+    padding: 24px 16px 64px;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Reduce visual clutter by simplifying the hero and section headers and removing decorative status chips/pills to focus on core controls.  
- Replace heavy gradients, colored shadows, and multi-colored status chips with a neutral, minimal palette for better readability.  
- Keep form controls and buttons accessible with consistent spacing, contrast, and clear focus states.  
- Verify responsive layout after simplification to ensure mobile breakpoints remain usable.  

### Description
- Updated `frontend/src/App.svelte` to remove the decorative `.pill` and `.chip` elements and the `statusTone` helper, and replaced complex `panel__header` blocks with a simple `header.section-header` containing `section-label` and `h2`.  
- Reworked `frontend/src/app.css` to remove radial/linear gradients, heavy shadows, and bright accent colors and to adopt a neutral palette and simplified borders, reduced radii, and subtler typography and spacing.  
- Standardized form control styles and focus outlines so inputs and selects use clear contrast (`outline: 2px solid #111827`) and buttons are consistent across the app for accessibility.  
- Adjusted a few responsive rules (page padding and layout gaps) to keep the layout usable at mobile breakpoints and retained existing form behavior and validation.  

### Testing
- Ran `npm install` in `frontend` and the install completed successfully.  
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 5173` and Vite started (site reachable).  
- Captured a full-page screenshot using a Playwright script to verify the simplified UI rendering, and the script completed successfully.  
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f0fd2c28c8327905898462c90a0a3)