### PR TITLE
Update App test to assert GPX/video/map tool inputs

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -8,9 +8,27 @@ describe('App', () => {
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
       'Run the GPX Helper API from the browser.'
     );
-    expect(screen.getByLabelText(/API base URL/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: /Trim GPX by time window/i })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/Start time/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/End time/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Trim track/i })).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: /Trim GPX using video/i })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Video file$/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Trim with video/i })).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: /Render map animation/i })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/Duration \(seconds\)/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Resolution/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Render animation/i })).toBeInTheDocument();
+
+    expect(screen.getAllByLabelText(/^GPX file$/i)).toHaveLength(3);
+    expect(screen.getByLabelText(/Optional video file/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### Motivation
- The UI was updated to emphasize tool sections (trim by time, trim by video, map animation) instead of exposing an API base URL input.
- Tests referencing the old API base URL need to be updated to avoid false negatives.
- Ensure there is at least one assertion per major tool to validate core user flows.
- Keep the main hero headline assertion if the hero remains present.

### Description
- Replaced the `API base URL` assertion in `frontend/src/App.test.js` with assertions for the trim-by-time section including the `Trim GPX by time window` heading and `Start time`/`End time` inputs.
- Added assertions for the video-assisted trim section including the `Trim GPX using video` heading, `Video file` input, and the `Trim with video` button.
- Added assertions for the map animation section including the `Render map animation` heading, `Duration (seconds)` input, `Resolution` select, and the `Render animation` button.
- Added checks that there are three `GPX file` inputs and that the `Optional video file` label exists, while preserving the level-1 hero headline check.

### Testing
- No automated test suite was executed as part of this change.
- The updated test file compiles locally and was committed to the repository.
- Further CI/unit test runs are required to validate the assertions in the project test runner.
- Manual review verified the assertions match the current component markup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f11805630832787a58874861ccbb1)