### PR TITLE
Send video metadata for trim-by-video requests

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -2,7 +2,7 @@
 
 This backend is a FastAPI service that exposes endpoints for working with GPX files.
 It accepts GPX uploads and trims the track data based on a requested time range or
-based on timestamps extracted from a companion video file.
+based on video metadata timestamps calculated by the client.
 
 ## How it works
 
@@ -12,13 +12,13 @@ The API is implemented in `backend/src/gpx_helper/api/main.py` and exposes:
 - `GET /api/v1/capabilities` to describe available endpoints.
 - `POST /api/v1/gpx/trim-by-time` to crop a GPX file to a provided time range.
 - `POST /api/v1/gpx/trim-by-video` to crop a GPX file based on the time range
-  extracted from an uploaded video.
+  provided by client-side video metadata.
 - `POST /api/v1/gpx/map-animate` to render a GPX track into an MP4 map animation
   using a requested duration and resolution.
 
 GPX trimming logic lives in `backend/src/gpx_helper/gpx_splitter.py`.
-The trim-by-video endpoint uses `get_video_times`, which reads video metadata via
-`exiftool` if it is available, then falls back to the file modification time.
+The trim-by-video endpoint expects the client to send start/end timestamps plus
+the video duration derived from metadata (for example, using the browser video tag).
 The map animation endpoint uses `backend/src/gpx_helper/map_animator.py`.
 
 ## Running the API locally
@@ -46,7 +46,9 @@ curl -X POST http://localhost:8000/api/v1/gpx/trim-by-time \
 ```bash
 curl -X POST http://localhost:8000/api/v1/gpx/trim-by-video \
   -F gpx_file=@/path/to/track.gpx \
-  -F video_file=@/path/to/video.MP4 \
+  -F start_time=2025-11-02T17:02:23Z \
+  -F end_time=2025-11-02T17:07:00Z \
+  -F duration_seconds=277 \
   --output trimmed.gpx
 ```
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from io import BytesIO
 import unittest
 from unittest import mock
 import xml.etree.ElementTree as ET
@@ -98,13 +96,14 @@ class ApiTests(unittest.TestCase):
     def test_trim_by_video_success(self) -> None:
         files = {
             "gpx_file": ("track.gpx", _build_gpx(), "application/gpx+xml"),
-            "video_file": ("clip.mp4", BytesIO(b"fake-video"), "video/mp4"),
         }
-        start_dt = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-        end_dt = datetime(2024, 1, 1, 0, 0, 20, tzinfo=timezone.utc)
+        data = {
+            "start_time": "2024-01-01T00:00:00Z",
+            "end_time": "2024-01-01T00:00:20Z",
+            "duration_seconds": "20",
+        }
 
-        with mock.patch("gpx_helper.api.main.get_video_times", return_value=(start_dt, end_dt)):
-            response = self.client.post("/api/v1/gpx/trim-by-video", files=files)
+        response = self.client.post("/api/v1/gpx/trim-by-video", files=files, data=data)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers["content-type"], "application/gpx+xml")


### PR DESCRIPTION
### Motivation
- Avoid uploading full video files when trimming GPX tracks to reduce bandwidth and improve privacy.
- Derive the clip start, end, and duration in the browser using video metadata and file timestamps.
- Simplify backend responsibilities by accepting pre-computed timestamps and duration from the client.

### Description
- Frontend: added `deriveVideoTimes` and updated the video-assisted trim flow to read duration via the browser `video` element and send `start_time`, `end_time`, and `duration_seconds` instead of the `video_file` to the API.
- Backend: changed `trim_by_video` to accept `start_time`, `end_time`, and `duration_seconds` as `Form` fields, removed video file handling, validated the times/duration, and call `crop_gpx_by_time` with the parsed datetimes.
- Documentation: updated `backend/README.md` to describe the new client-calculated metadata workflow for `POST /api/v1/gpx/trim-by-video`.
- Tests: updated `backend/tests/test_api.py` to post form fields for `trim-by-video` rather than uploading a video file.

### Testing
- Ran a frontend smoke check by launching the dev server and taking a Playwright screenshot of the updated UI, which completed successfully.
- Backend unit tests were not executed as part of this change; test files were updated to match the new request shape but not run automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695021cab64c8327bcb6dadd4d9a5e9d)