### PR TITLE
Clean up README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# GPX_helper
+# GPX Helper
 
-Utilities for aligning GoPro (or other camera) video timestamps with GPX tracks. The primary tool, `gpx_splitter.py`, crops a GPX track to match a video clip so you can sync footage and GPS data for mapping or overlays. The repository now includes a `frontend/` Svelte landing page and a `backend/` Python workspace that hosts the CLI tools.
+Utilities for aligning GoPro (or other camera) video timestamps with GPX tracks. The primary tool, `gpx_splitter.py`,
+crops a GPX track to match a video clip so you can sync footage and GPS data for mapping or overlays. The repository
+also includes a Svelte landing page in `frontend/` and a Python/FastAPI backend in `backend/`.
 
 ## Features
 - Extracts video start time and duration from EXIF metadata via `exiftool`.
@@ -25,6 +27,7 @@ sudo apt-get update && sudo apt-get install -y libimage-exiftool-perl  # Ubuntu/
 
 # Map animation dependencies
 pip install gpxpy matplotlib contextily
+
 # ffmpeg is required to write MP4 output
 brew install ffmpeg  # macOS
 sudo apt-get install -y ffmpeg  # Ubuntu/Debian
@@ -41,7 +44,7 @@ python3 backend/src/gpx_helper/gpx_splitter.py /path/to/video.MP4 /path/to/track
 If `-o/--output` is omitted, the script writes to `<input>.cropped.gpx` next to the original GPX file.
 
 ## Backend API (foundation)
-The backend now includes a FastAPI service that exposes endpoints for trimming GPX files by a known time window or by
+The backend includes a FastAPI service that trims GPX files by a known time window or by
 matching a video file. Start the API from the repository root:
 
 ```bash
@@ -76,8 +79,8 @@ curl -X POST http://localhost:8000/api/v1/gpx/map-animate \
 ```
 
 ## Animate a GPX route on a map
-`map_animator.py` turns a GPX track into an MP4 that draws the route over OpenStreetMap tiles. It converts coordinates to Web Mercator
-(EPSG:3857) so they align with the basemap and hides chart axes for a clean map view.
+`map_animator.py` turns a GPX track into an MP4 that draws the route over OpenStreetMap tiles. It converts
+coordinates to Web Mercator (EPSG:3857) so they align with the basemap and hides chart axes for a clean map view.
 
 Usage:
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,28 +1,24 @@
 # GPX Helper Backend
 
-This backend is a FastAPI service that exposes endpoints for working with GPX files.
-It accepts GPX uploads and trims the track data based on a requested time range or
-based on video metadata timestamps calculated by the client.
+FastAPI service that trims GPX files by time range or by video metadata.
 
 ## How it works
-
 The API is implemented in `backend/src/gpx_helper/api/main.py` and exposes:
 
 - `GET /api/v1/health` for a basic service check.
 - `GET /api/v1/capabilities` to describe available endpoints.
 - `POST /api/v1/gpx/trim-by-time` to crop a GPX file to a provided time range.
-- `POST /api/v1/gpx/trim-by-video` to crop a GPX file based on the time range
-  provided by client-side video metadata.
+- `POST /api/v1/gpx/trim-by-video` to crop a GPX file based on the time range provided
+  by client-side video metadata.
 - `POST /api/v1/gpx/map-animate` to render a GPX track into an MP4 map animation
   using a requested duration and resolution.
 
-GPX trimming logic lives in `backend/src/gpx_helper/gpx_splitter.py`.
-The trim-by-video endpoint expects the client to send start/end timestamps plus
-the video duration derived from metadata (for example, using the browser video tag).
-The map animation endpoint uses `backend/src/gpx_helper/map_animator.py`.
+GPX trimming logic lives in `backend/src/gpx_helper/gpx_splitter.py`. The trim-by-video
+endpoint expects the client to send start/end timestamps plus the video duration derived
+from metadata (for example, using the browser video tag). The map animation endpoint uses
+`backend/src/gpx_helper/map_animator.py`.
 
 ## Running the API locally
-
 Install dependencies with Poetry and run the app with Uvicorn:
 
 ```bash
@@ -61,9 +57,7 @@ curl -X POST http://localhost:8000/api/v1/gpx/map-animate \
 ```
 
 ## Running unit tests
-
-The backend unit tests are located in `backend/tests`.
-Run them from the `backend` directory:
+The backend unit tests are located in `backend/tests`. Run them from the `backend` directory:
 
 ```bash
 cd backend

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,18 +1,17 @@
 # GPX Helper Frontend
 
-## Prerequisites
+Svelte-based landing page for the GPX Helper tools.
 
+## Prerequisites
 - Node.js 18+
 - npm
 
-## Install
-
+## Install dependencies
 ```sh
 npm install
 ```
 
 ## Run the dev server
-
 ```sh
 npm run dev
 ```
@@ -20,19 +19,16 @@ npm run dev
 The app will be available at <http://localhost:4173>.
 
 ## Build for production
-
 ```sh
 npm run build
 ```
 
 ## Run tests
-
 ```sh
 npm run test
 ```
 
 ## Run tests in watch mode
-
 ```sh
 npm run test:watch
 ```


### PR DESCRIPTION
### Motivation
- Improve clarity and consistency across the repository documentation for new contributors and users.
- Standardize wording and headings for the root, backend, and frontend README files to make setup and usage easier to follow.
- Remove noisy or overly long sentences and ensure examples and commands are presented consistently.

### Description
- Updated `README.md`, `backend/README.md`, and `frontend/README.md` with streamlined wording and consistent title casing (`GPX Helper`).
- Reflowed long lines and clarified the backend API usage and example `curl` requests to make endpoint usage easier to read.
- Simplified the frontend README by consolidating headings and clarifying the install and dev commands such as `npm install` and `npm run dev`.
- These are documentation-only edits and do not change any application code or runtime behavior.

### Testing
- No automated tests were run because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69502e72b6e483279935f2799ada5d8f)