### PR TITLE
Validate video timestamps against GPX time range

### DIFF
--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -109,6 +109,21 @@ class ApiTests(unittest.TestCase):
         self.assertEqual(response.headers["content-type"], "application/gpx+xml")
         self.assertEqual(_count_trkpts(response.content), 3)
 
+    def test_trim_by_video_out_of_range(self) -> None:
+        files = {
+            "gpx_file": ("track.gpx", _build_gpx(), "application/gpx+xml"),
+        }
+        data = {
+            "start_time": "2023-12-31T23:59:50Z",
+            "end_time": "2024-01-01T00:00:10Z",
+            "duration_seconds": "20",
+        }
+
+        response = self.client.post("/api/v1/gpx/trim-by-video", files=files, data=data)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("outside GPX time range", response.json()["detail"])
+
     def test_map_animation_success(self) -> None:
         files = {
             "gpx_file": ("track.gpx", _build_gpx(), "application/gpx+xml"),


### PR DESCRIPTION
### Motivation

- Ensure `trim-by-video` requests don't crop a GPX track using video timestamps that fall outside the GPX's time span.
- Provide a clear error instead of producing an incorrect or empty cropped GPX when video metadata is out-of-range.

### Description

- Added `get_gpx_time_range` in `backend/src/gpx_helper/gpx_splitter.py` to compute the GPX track's min and max timestamps from `<time>` elements.
- Imported and used `get_gpx_time_range` in `backend/src/gpx_helper/api/main.py` to validate the requested `start_time`/`end_time` before cropping.
- When the video timestamps are outside the GPX range the API now returns an `HTTP 400` with the detail `"Video timestamps fall outside GPX time range"`.
- Added a unit test `test_trim_by_video_out_of_range` in `backend/tests/test_api.py` that asserts the out-of-range case returns `400` and includes the error text.

### Testing

- Added the automated test `test_trim_by_video_out_of_range` to `backend/tests/test_api.py` to cover the new validation.
- Existing unit tests for `trim-by-time`, `trim-by-video`, and `map-animate` remain in place and were updated/kept consistent with the change.
- No test suite was executed as part of this change (tests were added but not run).
- Manual code inspection and static checks were used to verify the new validation flow and error messaging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950b9e9b158832789f5fdf29e7479e1)