### PR TITLE
Prevent form field overlap in responsive grid

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -192,10 +192,13 @@ label {
   gap: 6px;
   font-weight: 600;
   color: #111827;
+  min-width: 0;
 }
 
 input,
 select {
+  width: 100%;
+  min-width: 0;
   padding: 10px 12px;
   border-radius: 10px;
   border: 1px solid #d1d5db;


### PR DESCRIPTION
### Motivation
- Certain mid-sized viewports caused form labels and inputs to overflow and overlap within the CSS grid layout.  
- The goal is to allow form grid items to shrink so fields fit cleanly into `repeat(auto-fit, minmax(...))` columns.  
- This change targets layout-only CSS fixes to improve usability without altering markup or behavior.  

### Description
- Updated `frontend/src/app.css` to add `min-width: 0` on `label` elements so grid children can shrink.  
- Set `width: 100%` and `min-width: 0` on `input, select` to prevent them from forcing column expansion.  
- These changes ensure form fields respect the column `minmax` constraints and stop overlapping at intermediate widths.  

### Testing
- Ran the frontend test suite with `npm test` (Vitest) and the single test file passed successfully.  
- The UI was visually verified at a mid-sized viewport to confirm overlap is resolved (non-test visual check performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69520864412c8327a445b509f5eabaa8)