### PR TITLE
Force Agg backend for map animation

### DIFF
--- a/backend/src/gpx_helper/map_animator.py
+++ b/backend/src/gpx_helper/map_animator.py
@@ -17,6 +17,10 @@ from typing import Iterable
 
 import gpxpy
 import gpxpy.gpx
+import matplotlib
+
+matplotlib.use("Agg")
+
 import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation, FFMpegWriter
 import contextily as cx


### PR DESCRIPTION
### Motivation
- Avoid the macOS error about creating a GUI FigureManager off the main thread by using a non-interactive backend.
- Make `map_animator.py` safe to run in worker threads and CI environments where no display is available.

### Description
- Set the Matplotlib backend with `matplotlib.use("Agg")` before importing `matplotlib.pyplot` in `backend/src/gpx_helper/map_animator.py`.
- Reordered imports so the backend is configured early while preserving existing animation and basemap logic.
- No changes to the animation logic or output format; this only enforces a headless rendering backend.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695209f3b55c8327b5b4522d2461a847)