### PR TITLE
Fix unittest discovery in backend checks

### DIFF
--- a/.github/workflows/pr-structure-check.yml
+++ b/.github/workflows/pr-structure-check.yml
@@ -27,7 +27,7 @@ jobs:
         run: poetry install --no-interaction --no-ansi
 
       - name: Run backend unit tests
-        run: poetry run python -m unittest
+        run: poetry run python -m unittest discover -s tests
 
   frontend-check:
     name: Frontend structure

--- a/backend/README.md
+++ b/backend/README.md
@@ -61,5 +61,5 @@ The backend unit tests are located in `backend/tests`. Run them from the `backen
 
 ```bash
 cd backend
-poetry run python -m unittest
+poetry run python -m unittest discover -s tests
 ```


### PR DESCRIPTION
### Motivation
- The CI workflow invoked `python -m unittest` without discovery, which runs zero tests when no explicit targets are provided.
- This allowed backend tests under `backend/tests` to be skipped and could let CI pass despite failing tests.
- The README's test instructions matched the incorrect command, leading to confusion for local runs.

### Description
- Update the PR workflow step to run `poetry run python -m unittest discover -s tests` so tests in `backend/tests` are discovered and executed.
- Align `backend/README.md` to instruct running `poetry run python -m unittest discover -s tests` from the `backend` directory.
- Modified files: `.github/workflows/pr-structure-check.yml` and `backend/README.md`.

### Testing
- No automated tests were executed as part of this PR because the change is a CI/workflow command update.
- The change is limited to workflow and documentation, not application code, so no unit test modifications were required.
- CI should now run backend tests via discovery on subsequent runs (not verified in this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952c84288f083279af5ba1f7ac5216d)