### PR TITLE
Validate resolution in map-animate ETA endpoint

### DIFF
--- a/backend/src/gpx_helper/api/main.py
+++ b/backend/src/gpx_helper/api/main.py
@@ -180,6 +180,8 @@ def estimate_map_animation(
         width_px, height_px = parse_resolution(resolution)
     except Exception as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if width_px <= 0 or height_px <= 0:
+        raise HTTPException(status_code=400, detail="resolution must be positive")
 
     with tempfile.NamedTemporaryFile(suffix=".gpx") as gpx_input:
         _write_upload_to_file(gpx_file, gpx_input, "GPX")


### PR DESCRIPTION
### Motivation
- The `/api/v1/gpx/map-animate/estimate` endpoint parsed resolutions but did not reject non-positive dimensions, allowing inputs like `0x0` or `-640x480` to return a misleading ETA.
- Those invalid resolutions will fail later when the real render path builds Matplotlib figures with non-positive sizes, so the ETA endpoint should fail early.
- This change brings the ETA endpoint validation closer to the behavior of the render `/map-animate` endpoint.

### Description
- Added a validation check in `backend/src/gpx_helper/api/main.py` after `parse_resolution` to ensure `width_px` and `height_px` are positive.
- If either dimension is non-positive the endpoint now raises `HTTPException(status_code=400, detail="resolution must be positive")`.
- No other behavior or endpoints were modified.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953f97c2f548327ae69332e933c134d)