### PR TITLE
Update App UI test after removing video trim card

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -5,9 +5,7 @@ describe('App', () => {
   it('renders the hero headline and key actions', () => {
     render(App);
 
-    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
-      'Run the GPX Helper API from the browser.'
-    );
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('GPX Helper');
     expect(
       screen.getByRole('heading', { level: 2, name: /Trim GPX by time window/i })
     ).toBeInTheDocument();
@@ -16,19 +14,13 @@ describe('App', () => {
     expect(screen.getByRole('button', { name: /Trim track/i })).toBeInTheDocument();
 
     expect(
-      screen.getByRole('heading', { level: 2, name: /Trim GPX using video/i })
-    ).toBeInTheDocument();
-    expect(screen.getByLabelText(/^Video file$/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Trim with video/i })).toBeInTheDocument();
-
-    expect(
       screen.getByRole('heading', { level: 2, name: /Render map animation/i })
     ).toBeInTheDocument();
     expect(screen.getByLabelText(/Duration \(seconds\)/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Resolution/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Render animation/i })).toBeInTheDocument();
 
-    expect(screen.getAllByLabelText(/^GPX file$/i)).toHaveLength(3);
+    expect(screen.getAllByLabelText(/^GPX file$/i)).toHaveLength(2);
     expect(screen.getByLabelText(/Optional video file/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### Motivation
- The UI no longer includes the “Trim GPX using video” card in `frontend/src/App.svelte`, so tests that assert those elements will fail.
- The unit test needs to be aligned with the current page heading and form inputs to keep the frontend tests valid.

### Description
- Updated `frontend/src/App.test.js` to expect the hero heading text `GPX Helper` instead of the previous full sentence.
- Removed assertions that checked the `Trim GPX using video` heading, the `Video file` input, and the `Trim with video` button.
- Adjusted the expected number of `GPX file` inputs from `3` to `2` to reflect the removed card.

### Testing
- No automated tests were executed as part of this change.
- The frontend test suite will run in CI when the PR is opened to validate the update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695972720f488327883eae290b621c8a)