### PR TITLE
Add Dockerfile for backend Render deployment

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -25,4 +25,4 @@ COPY . /app
 EXPOSE 10000
 
 # Start FastAPI
-CMD ["uvicorn", "gpx_helper.api.main:app", "--host", "0.0.0.0", "--port", "${PORT}"]
+CMD ["sh", "-c", "uvicorn gpx_helper.api.main:app --host 0.0.0.0 --port ${PORT}"]


### PR DESCRIPTION
### Motivation

- Enable deploying the FastAPI backend on Render as a Docker Web Service so OS-level packages can be installed.
- Provide `ffmpeg` and `exiftool` for backend features that depend on them. 
- Use a Poetry-based install with no virtualenv to match the project dependency setup. 
- Ensure the service binds to `0.0.0.0` and uses the `${PORT}` environment variable for Render compatibility.

### Description

- Add `backend/Dockerfile` based on `FROM python:3.11-slim` to build the backend container image.
- Install system packages `ffmpeg` and `libimage-exiftool-perl` and clean apt caches. 
- Install Poetry, copy `pyproject.toml` and `poetry.lock`, and run `poetry config virtualenvs.create false` followed by `poetry install` to install dependencies. 
- Copy the backend sources, `EXPOSE 10000`, and start the app with `CMD ["uvicorn", "gpx_helper.api.main:app", "--host", "0.0.0.0", "--port", "${PORT}"]`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b408cbdd88327ab047dd05d97ecc8)