### PR TITLE
Group render map animation options in UI

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -178,7 +178,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -202,7 +201,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -971,7 +969,6 @@
       "integrity": "sha512-Txsm1tJvtiYeLUVRNqxZGKR/mI+CzuIQuc2gn+YCs9rMTowpNZ2Nqt53JdL8KF9bLhAf2ruR/dr9eZCwdTriRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^2.1.0",
         "debug": "^4.3.4",
@@ -2778,7 +2775,6 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -3327,7 +3323,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3856,7 +3851,6 @@
       "integrity": "sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -4073,7 +4067,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4116,7 +4109,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -479,82 +479,92 @@
             required
           />
         </label>
-        <label>
-          Resolution width (px)
-          <input
-            type="number"
-            min="1"
-            step="1"
-            bind:value={mapAnimation.resolutionWidth}
-            placeholder="1024"
-            required
-          />
-        </label>
-        <label>
-          Resolution height (px)
-          <input
-            type="number"
-            min="1"
-            step="1"
-            bind:value={mapAnimation.resolutionHeight}
-            placeholder="1024"
-            required
-          />
-        </label>
-        <label>
-          Marker color
-          <input type="color" bind:value={mapAnimation.markerColor} />
-        </label>
-        <label>
-          Marker size (px)
-          <input
-            type="number"
-            min="1"
-            step="0.5"
-            bind:value={mapAnimation.markerSize}
-            placeholder="6"
-          />
-        </label>
-        <label>
-          Animated trail color
-          <input type="color" bind:value={mapAnimation.trailColor} />
-        </label>
-        <label>
-          Full trail color
-          <input type="color" bind:value={mapAnimation.fullTrailColor} />
-        </label>
-        <label>
-          Full trail opacity
-          <input
-            type="number"
-            min="0"
-            max="1"
-            step="0.05"
-            bind:value={mapAnimation.fullTrailOpacity}
-            placeholder="0.8"
-          />
-        </label>
-        <label>
-          Line width (px)
-          <input
-            type="number"
-            min="0.5"
-            step="0.1"
-            bind:value={mapAnimation.lineWidth}
-            placeholder="2.5"
-          />
-        </label>
-        <label>
-          Animated line opacity
-          <input
-            type="number"
-            min="0"
-            max="1"
-            step="0.05"
-            bind:value={mapAnimation.lineOpacity}
-            placeholder="1"
-          />
-        </label>
+        <div class="options-group">
+          <p class="options-title">Output size</p>
+          <div class="options-grid">
+            <label>
+              Resolution width (px)
+              <input
+                type="number"
+                min="1"
+                step="1"
+                bind:value={mapAnimation.resolutionWidth}
+                placeholder="1024"
+                required
+              />
+            </label>
+            <label>
+              Resolution height (px)
+              <input
+                type="number"
+                min="1"
+                step="1"
+                bind:value={mapAnimation.resolutionHeight}
+                placeholder="1024"
+                required
+              />
+            </label>
+          </div>
+        </div>
+        <div class="options-group">
+          <p class="options-title">Style options</p>
+          <div class="options-grid">
+            <label>
+              Marker color
+              <input type="color" bind:value={mapAnimation.markerColor} />
+            </label>
+            <label>
+              Marker size (px)
+              <input
+                type="number"
+                min="1"
+                step="0.5"
+                bind:value={mapAnimation.markerSize}
+                placeholder="6"
+              />
+            </label>
+            <label>
+              Animated trail color
+              <input type="color" bind:value={mapAnimation.trailColor} />
+            </label>
+            <label>
+              Full trail color
+              <input type="color" bind:value={mapAnimation.fullTrailColor} />
+            </label>
+            <label>
+              Full trail opacity
+              <input
+                type="number"
+                min="0"
+                max="1"
+                step="0.05"
+                bind:value={mapAnimation.fullTrailOpacity}
+                placeholder="0.8"
+              />
+            </label>
+            <label>
+              Line width (px)
+              <input
+                type="number"
+                min="0.5"
+                step="0.1"
+                bind:value={mapAnimation.lineWidth}
+                placeholder="2.5"
+              />
+            </label>
+            <label>
+              Animated line opacity
+              <input
+                type="number"
+                min="0"
+                max="1"
+                step="0.05"
+                bind:value={mapAnimation.lineOpacity}
+                placeholder="1"
+              />
+            </label>
+          </div>
+        </div>
         <div class="form-actions">
           <button type="submit" disabled={isBusy}>Render animation</button>
           <p class="hint">Duration auto-fills from the GPX timestamps when available.</p>

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -239,6 +239,28 @@ select:disabled {
   gap: 12px;
 }
 
+.options-group {
+  grid-column: 1 / -1;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 12px 14px;
+  background: #ffffff;
+  display: grid;
+  gap: 10px;
+}
+
+.options-title {
+  margin: 0;
+  font-weight: 600;
+  color: #111827;
+}
+
+.options-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
 label {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
### Motivation
- The Render map animation form presented many individual inputs which made the section visually overwhelming.
- Grouping related controls improves scanability and makes configuration clearer for users.

### Description
- Reorganized the map animation inputs in `frontend/src/App.svelte` into two panels titled `Output size` and `Style options` containing the relevant fields.
- Added CSS for the new panels with `.options-group`, `.options-grid`, and `.options-title` in `frontend/src/app.css` to style and layout the grouped controls.
- Updated the frontend lockfile via `npm install` (reflected changes in `frontend/package-lock.json`).

### Testing
- Ran `npm test` (Vitest) in the `frontend` folder and all tests passed.
- Executed an automated Playwright smoke script that opened the dev site and captured `artifacts/render-map-animation-grouped.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d79b98e2c83279939b905b0ffc6b7)