### PR TITLE
Allow server default map tiles in map animation form

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -22,7 +22,7 @@
     durationSeconds: 45,
     resolutionWidth: 1024,
     resolutionHeight: 1024,
-    tileType: 'osm',
+    tileType: '',
     markerColor: '#0ea5e9',
     trailColor: '#0ea5e9',
     fullTrailColor: '#111827',
@@ -38,6 +38,7 @@
   };
 
   const mapTileOptions = [
+    { value: '', label: 'Server default' },
     { value: 'osm', label: 'OpenStreetMap (Standard)' },
     { value: 'cyclosm', label: 'CyclOSM' },
     { value: 'opentopomap', label: 'OpenTopoMap (Topo)' }
@@ -318,7 +319,9 @@
       formData.append('marker_size', String(mapAnimation.markerSize));
       formData.append('line_width', String(mapAnimation.lineWidth));
       formData.append('line_opacity', String(mapAnimation.lineOpacity));
-      formData.append('tile_type', mapAnimation.tileType);
+      if (mapAnimation.tileType) {
+        formData.append('tile_type', mapAnimation.tileType);
+      }
 
       requestEta('/api/v1/gpx/map-animate/estimate', cloneFormData(formData))
         .then((eta) => {


### PR DESCRIPTION
### Motivation
- The frontend was always sending `tile_type` initialized to `'osm'`, which prevented the backend from using its configured MAP_TILE_URL_TEMPLATE/MAP_TILE_SUBDOMAINS defaults.
- The intent is to let the server fall back to its configured default tile provider when the user has not explicitly chosen one.
- Add a UI affordance to make the server-default behavior discoverable.

### Description
- Change the default `mapAnimation.tileType` from `'osm'` to an empty string `''` so no provider is assumed.
- Add a `Server default` option (`{ value: '', label: 'Server default' }`) to `mapTileOptions` in `frontend/src/App.svelte`.
- Only append `tile_type` to the request `FormData` when `mapAnimation.tileType` is set, avoiding sending the field when the server default should apply.

### Testing
- Started the frontend dev server with `npm run dev` and it launched successfully.
- Executed a Playwright script that loaded the frontend and saved a screenshot (`artifacts/map-tile-default.png`) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dc99c84c48327bcc095a0ec70ef11)