### PR TITLE
Enforce MAP_ANIM_MAX_FRAMES for long-duration animations

### DIFF
--- a/backend/src/gpx_helper/map_animator.py
+++ b/backend/src/gpx_helper/map_animator.py
@@ -156,11 +156,11 @@ def _ffmpeg_preset_speed_factor(preset: str) -> float:
     return FFMPEG_PRESET_SPEED.get(preset, FFMPEG_PRESET_SPEED["veryfast"])
 
 
-def _resolve_effective_fps(duration_sec: float, fps: int) -> int:
+def _resolve_effective_fps(duration_sec: float, fps: float) -> float:
     if duration_sec <= 0 or DEFAULT_MAX_FRAMES <= 0:
-        return fps
-    max_fps = max(1, int(DEFAULT_MAX_FRAMES / duration_sec))
-    return min(fps, max_fps)
+        return float(fps)
+    max_fps = DEFAULT_MAX_FRAMES / duration_sec
+    return min(float(fps), max_fps)
 
 
 @lru_cache(maxsize=256)
@@ -348,8 +348,11 @@ def fetch_basemap_image(
 
 
 def prepare_animation_data(
-    xs: list[float], ys: list[float], duration_sec: float, fps: int = DEFAULT_FPS
-) -> tuple[list[int], int, int]:
+    xs: list[float],
+    ys: list[float],
+    duration_sec: float,
+    fps: float = DEFAULT_FPS,
+) -> tuple[list[int], int, float]:
     """
     Prepare per-frame indices along the route.
     """

--- a/backend/tests/test_map_animator.py
+++ b/backend/tests/test_map_animator.py
@@ -66,6 +66,16 @@ class MapAnimatorTests(unittest.TestCase):
         self.assertEqual(len(ys_out), len(ys))
         self.assertEqual(len(frame_indices), total_frames)
 
+    def test_prepare_animation_series_caps_total_frames_for_long_duration(self) -> None:
+        xs = [0.0, 1.0, 2.0]
+        ys = [0.0, 1.0, 2.0]
+
+        with mock.patch.object(map_animator, "DEFAULT_MAX_FRAMES", 2400):
+            _, _, _, total_frames, fps = prepare_animation_series(xs, ys, 3600.0, fps=30)
+
+        self.assertLessEqual(total_frames, map_animator.DEFAULT_MAX_FRAMES)
+        self.assertLess(fps, 1.0)
+
     def test_estimate_animation_seconds_respects_preset_speed(self) -> None:
         lats = [0.0, 0.0, 0.01]
         lons = [0.0, 0.01, 0.02]


### PR DESCRIPTION
### Motivation

- `_resolve_effective_fps` previously forced a minimum FPS of 1 which allowed `total_frames` to exceed the configured `MAP_ANIM_MAX_FRAMES` for long durations.
- The intent is to make `MAP_ANIM_MAX_FRAMES` a hard cap on total frames so very long animations do not produce excessive frames and slow renders.
- Allowing effective FPS to drop below 1.0 (or otherwise clamping total frames) is required to enforce that ceiling.

### Description

- Changed `_resolve_effective_fps` to accept and return `float` and compute `max_fps = DEFAULT_MAX_FRAMES / duration_sec` without forcing a minimum of 1.0 so effective FPS can be < 1.0.
- Updated `prepare_animation_data` type hints to accept a `float` FPS and return a `float` FPS to propagate fractional FPS through the pipeline.
- Added a regression test `test_prepare_animation_series_caps_total_frames_for_long_duration` to assert `total_frames <= DEFAULT_MAX_FRAMES` and that `fps < 1.0` for very long durations.

### Testing

- Ran `python -m pytest backend/tests/test_map_animator.py` and all tests passed (6 passed).
- The new test verifies long-duration behavior and the existing suite confirms no regressions in animation frame logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dde15e9d48327b84bced126ef82f6)