### PR TITLE
Resize basemap to match animation frame size

### DIFF
--- a/backend/src/gpx_helper/map_animator.py
+++ b/backend/src/gpx_helper/map_animator.py
@@ -529,6 +529,8 @@ def create_animation(
         tile_subdomains=tile_subdomains,
     )
     base_image = basemap_image.convert("RGBA")
+    if base_image.size != (width_px, height_px):
+        base_image = base_image.resize((width_px, height_px), Image.Resampling.LANCZOS)
     point_pixels = _project_points_to_pixels(
         xs_arr, ys_arr, basemap_extent, width_px, height_px
     )


### PR DESCRIPTION
### Motivation
- The stitched basemap returned by `fetch_basemap_image` can be a multiple of 256 tiles and not match the requested `width_px`/`height_px`, producing frames with the wrong buffer size for ffmpeg.
- When the basemap size differs from the requested frame size the point projection and trail drawing end up scaled/misaligned because projection uses `width_px`/`height_px` while the image uses tile-rounded dimensions.

### Description
- After converting the fetched basemap to RGBA, resize it to `(width_px, height_px)` when `base_image.size` does not match those dimensions using `Image.Resampling.LANCZOS`.
- The resize happens before calling `_project_points_to_pixels` and before creating `trail_image`, ensuring drawn frames and `frame_image.tobytes()` match ffmpeg's expected buffer size.
- Change applied to `backend/src/gpx_helper/map_animator.py` adjacent to the `fetch_basemap_image` usage.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69655e097de88327a20fa0889d7d5a14)