### PR TITLE
Preserve transparency in telemetry overlay exports

### DIFF
--- a/backend/src/gpx_helper/api/main.py
+++ b/backend/src/gpx_helper/api/main.py
@@ -464,7 +464,10 @@ def render_telemetry_video(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    output_background = parse_background_color(background_color)
+    try:
+        output_background = parse_background_color(background_color)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     has_alpha = output_background[3] < 255
     output_suffix = ".webm" if has_alpha else ".mp4"
     output_media_type = "video/webm" if has_alpha else "video/mp4"

--- a/backend/src/gpx_helper/api/main.py
+++ b/backend/src/gpx_helper/api/main.py
@@ -30,6 +30,7 @@ from gpx_helper.telemetry_animator import (
     ensure_telemetry_type_supported,
     estimate_telemetry_seconds,
     load_gpx_telemetry,
+    parse_background_color,
     resolve_telemetry_type,
 )
 
@@ -463,8 +464,13 @@ def render_telemetry_video(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
+    output_background = parse_background_color(background_color)
+    has_alpha = output_background[3] < 255
+    output_suffix = ".webm" if has_alpha else ".mp4"
+    output_media_type = "video/webm" if has_alpha else "video/mp4"
+
     with tempfile.NamedTemporaryFile(suffix=".gpx") as gpx_input, tempfile.NamedTemporaryFile(
-        suffix=".mp4"
+        suffix=output_suffix
     ) as video_output:
         _write_upload_to_file(gpx_file, gpx_input, "GPX")
         try:
@@ -486,5 +492,5 @@ def render_telemetry_video(
         video_output.seek(0)
         upload_name = os.path.basename(gpx_file.filename or "")
         stem = os.path.splitext(upload_name)[0] if upload_name else "telemetry"
-        output_name = f"{stem}-{resolved_type}.mp4"
-        return _stream_payload(video_output.read(), output_name, "video/mp4")
+        output_name = f"{stem}-{resolved_type}{output_suffix}"
+        return _stream_payload(video_output.read(), output_name, output_media_type)

--- a/backend/src/gpx_helper/telemetry_animator.py
+++ b/backend/src/gpx_helper/telemetry_animator.py
@@ -466,10 +466,11 @@ def _open_ffmpeg_writer(
     width_px: int,
     height_px: int,
     fps: float,
+    use_alpha: bool,
 ) -> "subprocess.Popen[bytes]":
     import subprocess
 
-    cmd = [
+    cmd: list[str] = [
         "ffmpeg",
         "-y",
         "-f",
@@ -485,16 +486,36 @@ def _open_ffmpeg_writer(
         "-i",
         "-",
         "-an",
-        "-vcodec",
-        "libx264",
-        "-preset",
-        "veryfast",
-        "-crf",
-        "23",
-        "-pix_fmt",
-        "yuv420p",
-        output_path,
     ]
+    if use_alpha:
+        cmd.extend(
+            [
+                "-vcodec",
+                "libvpx-vp9",
+                "-b:v",
+                "0",
+                "-crf",
+                "30",
+                "-auto-alt-ref",
+                "0",
+                "-pix_fmt",
+                "yuva420p",
+            ]
+        )
+    else:
+        cmd.extend(
+            [
+                "-vcodec",
+                "libx264",
+                "-preset",
+                "veryfast",
+                "-crf",
+                "23",
+                "-pix_fmt",
+                "yuv420p",
+            ]
+        )
+    cmd.append(output_path)
     return subprocess.Popen(cmd, stdin=subprocess.PIPE)
 
 
@@ -513,6 +534,7 @@ def create_telemetry_animation(
     ensure_telemetry_type_supported(points, resolved_type)
     source_duration_seconds = telemetry_duration_seconds(points)
     background_rgba = parse_background_color(background_color)
+    use_alpha = background_rgba[3] < 255
     times, values = _metric_series(points, resolved_type)
     effective_fps = _resolve_effective_fps(duration_seconds, fps)
     total_frames = max(int(duration_seconds * effective_fps), 2)
@@ -521,6 +543,7 @@ def create_telemetry_animation(
         width_px=width_px,
         height_px=height_px,
         fps=effective_fps,
+        use_alpha=use_alpha,
     )
     if ffmpeg_proc.stdin is None:
         raise RuntimeError("Failed to open ffmpeg pipe for writing.")

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -466,6 +466,22 @@ class ApiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn("heart rate data", response.json()["detail"])
 
+    def test_telemetry_video_rejects_invalid_background_color(self) -> None:
+        files = {
+            "gpx_file": ("ride.gpx", _build_gpx_with_telemetry(), "application/gpx+xml"),
+        }
+        data = {
+            "duration_seconds": "20",
+            "fps": "30",
+            "resolution": "640x640",
+            "telemetry_type": "heart_rate",
+            "background_color": "not-a-color",
+        }
+
+        response = self.client.post("/api/v1/gpx/telemetry-video", files=files, data=data)
+
+        self.assertEqual(response.status_code, 400)
+
     def test_telemetry_video_estimate_success(self) -> None:
         files = {
             "gpx_file": ("ride.gpx", _build_gpx_with_telemetry(), "application/gpx+xml"),

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -390,12 +390,48 @@ class ApiTests(unittest.TestCase):
             "telemetry_type": "heart_rate",
             "background_color": "transparent",
         }
-        fake_video = b"telemetry-mp4"
+        fake_video = b"telemetry-webm"
         captured = {}
 
         def _fake_telemetry_animation(points, **kwargs):
             captured["point_count"] = len(points)
             captured.update(kwargs)
+            with open(kwargs["output_path"], "wb") as f:
+                f.write(fake_video)
+
+        with mock.patch(
+            "gpx_helper.api.main.create_telemetry_animation",
+            side_effect=_fake_telemetry_animation,
+        ):
+            response = self.client.post("/api/v1/gpx/telemetry-video", files=files, data=data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "video/webm")
+        self.assertEqual(response.content, fake_video)
+        self.assertIn(
+            "attachment; filename=ride-heart_rate.webm",
+            response.headers["content-disposition"],
+        )
+        self.assertEqual(captured["point_count"], 3)
+        self.assertEqual(captured["telemetry_type"], "heart_rate")
+        self.assertEqual(captured["background_color"], "transparent")
+        self.assertEqual(captured["width_px"], 640)
+        self.assertEqual(captured["height_px"], 640)
+
+    def test_telemetry_video_opaque_background_returns_mp4(self) -> None:
+        files = {
+            "gpx_file": ("ride.gpx", _build_gpx_with_telemetry(), "application/gpx+xml"),
+        }
+        data = {
+            "duration_seconds": "20",
+            "fps": "30",
+            "resolution": "640x640",
+            "telemetry_type": "heart_rate",
+            "background_color": "#000000",
+        }
+        fake_video = b"telemetry-mp4"
+
+        def _fake_telemetry_animation(points, **kwargs):
             with open(kwargs["output_path"], "wb") as f:
                 f.write(fake_video)
 
@@ -412,11 +448,6 @@ class ApiTests(unittest.TestCase):
             "attachment; filename=ride-heart_rate.mp4",
             response.headers["content-disposition"],
         )
-        self.assertEqual(captured["point_count"], 3)
-        self.assertEqual(captured["telemetry_type"], "heart_rate")
-        self.assertEqual(captured["background_color"], "transparent")
-        self.assertEqual(captured["width_px"], 640)
-        self.assertEqual(captured["height_px"], 640)
 
     def test_telemetry_video_rejects_missing_heart_rate_data(self) -> None:
         files = {

--- a/backend/tests/test_telemetry_animator.py
+++ b/backend/tests/test_telemetry_animator.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import os
 import tempfile
 import unittest
+from unittest import mock
 
+import gpx_helper.telemetry_animator as telemetry_animator
 from gpx_helper.telemetry_animator import (
     ensure_telemetry_type_supported,
     load_gpx_telemetry,
@@ -75,6 +77,21 @@ class TelemetryAnimatorTests(unittest.TestCase):
     def test_parse_background_color_supports_transparent_keyword(self) -> None:
         self.assertEqual(parse_background_color("transparent"), (0, 0, 0, 0))
         self.assertEqual(parse_background_color("#112233"), (17, 34, 51, 255))
+
+    def test_open_ffmpeg_writer_uses_alpha_capable_encoding(self) -> None:
+        with mock.patch("subprocess.Popen") as mock_popen:
+            telemetry_animator._open_ffmpeg_writer(
+                "/tmp/out.webm",
+                width_px=640,
+                height_px=360,
+                fps=30.0,
+                use_alpha=True,
+            )
+
+        cmd = mock_popen.call_args.args[0]
+        self.assertIn("libvpx-vp9", cmd)
+        self.assertIn("yuva420p", cmd)
+        self.assertNotIn("libx264", cmd)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- The telemetry exporter always forced `-pix_fmt yuv420p` which strips alpha and irreversibly flattens `background_color=transparent` overlays. 
- The intent is to preserve alpha for overlay-style telemetry renders so downstream compositing keeps intended transparency.

### Description
- Switch the ffmpeg encoding path to choose an alpha-capable codec/pixel format when the requested background has alpha by adding a `use_alpha` flag to `_open_ffmpeg_writer` and selecting `libvpx-vp9` + `yuva420p` for alpha output.  
- Keep the existing `libx264` + `yuv420p` path for opaque backgrounds so non-transparent exports remain MP4-compatible.  
- Detect background alpha in `create_telemetry_animation` via `parse_background_color` and pass `use_alpha` into the ffmpeg writer.  
- Update the telemetry API to return `.webm` / `video/webm` when transparency is requested and retain `.mp4` / `video/mp4` for opaque outputs, and adjust the output filename suffix accordingly.  
- Add/modify tests: `backend/tests/test_api.py` now asserts transparent telemetry returns WebM and includes a test ensuring opaque backgrounds still return MP4, and `backend/tests/test_telemetry_animator.py` adds a unit test that the ffmpeg command for alpha output contains `libvpx-vp9` and `yuva420p`.

### Testing
- Ran `pytest backend/tests/test_telemetry_animator.py backend/tests/test_api.py`, which failed during collection in this environment due to missing Python dependencies (`numpy` and `fastapi`).  
- Executed `python -m compileall backend/src`, which succeeded for the modified modules.  
- Added unit tests that mock `subprocess.Popen` to verify ffmpeg command selection, and updated API tests to verify returned media type and filename suffix; those tests are included but could not be executed end-to-end here due to the dependency errors above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e559502b4083279df0e273e3fced04)