### PR TITLE
Update tests, CI checks, and README after refactor

### DIFF
--- a/.github/workflows/pr-structure-check.yml
+++ b/.github/workflows/pr-structure-check.yml
@@ -52,5 +52,8 @@ jobs:
       - name: Run frontend checks
         run: npm run check
 
+      - name: Run frontend tests
+        run: npm test -- --run
+
       - name: Build frontend
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Utilities for aligning GoPro (or other camera) video timestamps with GPX tracks. The primary tool, `gpx_splitter.py`,
 crops a GPX track to match a video clip so you can sync footage and GPS data for mapping or overlays. The repository
-also includes a Svelte landing page in `frontend/` and a Python/FastAPI backend in `backend/`.
+also includes a Svelte + Vite frontend in `frontend/` and a Python/FastAPI backend (managed with Poetry) in `backend/`.
 
 ## Features
 - Extracts video start time and duration from EXIF metadata via `exiftool`.
@@ -10,27 +10,34 @@ also includes a Svelte landing page in `frontend/` and a Python/FastAPI backend 
 - Falls back to file modification time when metadata is missing, with clear warnings.
 - Works with GPX files that include timezone-aware timestamps (UTC recommended).
 - Renders GPX tracks into MP4 map animations with OpenStreetMap tiles.
+- Supports multi-clip trimming and telemetry video rendering (heart rate, speed, elevation).
 
 ## Requirements
-- Python 3.8+
+- Python 3.13+
 - [`exiftool`](https://exiftool.org/) available in your `PATH` (for `gpx_splitter.py`)
-- `gpxpy`, `matplotlib`, `folium`, and `pillow` Python packages (for map animation)
+- Backend Python dependencies installed via Poetry (`gpxpy`, `matplotlib`, `pillow`, `numpy`, `fastapi`, etc.)
 - [`ffmpeg`](https://ffmpeg.org/) available in your `PATH` when exporting video
+- Node.js 20+ and npm (for the frontend)
 
 ## Installation
-Clone or download this repository. Install the tools you need for the backend:
+Clone or download this repository. Install the system tools, then install project dependencies:
 
 ```bash
 # Core dependency for gpx_splitter.py
 brew install exiftool  # macOS
 sudo apt-get update && sudo apt-get install -y libimage-exiftool-perl  # Ubuntu/Debian
 
-# Map animation dependencies
-pip install gpxpy matplotlib folium pillow
-
 # ffmpeg is required to write MP4 output
 brew install ffmpeg  # macOS
 sudo apt-get install -y ffmpeg  # Ubuntu/Debian
+
+# Backend dependencies
+cd backend
+poetry install
+
+# Frontend dependencies
+cd ../frontend
+npm ci
 ```
 
 ## Backend usage
@@ -44,8 +51,8 @@ python3 backend/src/gpx_helper/gpx_splitter.py /path/to/video.MP4 /path/to/track
 If `-o/--output` is omitted, the script writes to `<input>.cropped.gpx` next to the original GPX file.
 
 ## Backend API (foundation)
-The backend includes a FastAPI service that trims GPX files by a known time window or by
-matching a video file. Start the API from the repository root:
+The backend includes a FastAPI service for GPX trimming, map animation, and telemetry video rendering.
+Start the API from the repository root:
 
 ```bash
 cd backend
@@ -66,8 +73,17 @@ curl -X POST http://localhost:8000/api/v1/gpx/trim-by-time \
 ```bash
 curl -X POST http://localhost:8000/api/v1/gpx/trim-by-video \
   -F gpx_file=@/path/to/track.gpx \
-  -F video_file=@/path/to/video.MP4 \
+  -F start_time=2025-11-02T17:02:23Z \
+  -F end_time=2025-11-02T17:07:00Z \
+  -F duration_seconds=277 \
   --output trimmed.gpx
+```
+
+```bash
+curl -X POST http://localhost:8000/api/v1/gpx/trim-by-videos \
+  -F gpx_file=@/path/to/track.gpx \
+  -F 'clips_json=[{"start_time":"2025-11-02T17:02:23Z","end_time":"2025-11-02T17:07:00Z","duration_seconds":277}]' \
+  --output trimmed.zip
 ```
 
 ```bash
@@ -82,6 +98,23 @@ curl -X POST http://localhost:8000/api/v1/gpx/map-animate/estimate \
   -F gpx_file=@/path/to/track.gpx \
   -F duration_seconds=45 \
   -F resolution=1920x1080
+```
+
+```bash
+curl -X POST http://localhost:8000/api/v1/gpx/telemetry-video \
+  -F gpx_file=@/path/to/track.gpx \
+  -F duration_seconds=45 \
+  -F resolution=1080x1080 \
+  -F telemetry_type=heart_rate \
+  -F background_color=transparent \
+  --output telemetry.webm
+
+# Ask for telemetry render ETA (JSON response)
+curl -X POST http://localhost:8000/api/v1/gpx/telemetry-video/estimate \
+  -F gpx_file=@/path/to/track.gpx \
+  -F duration_seconds=45 \
+  -F resolution=1080x1080 \
+  -F telemetry_type=heart_rate
 ```
 
 ## Animate a GPX route on a map
@@ -143,10 +176,13 @@ npm install
 npm run dev
 ```
 
-Then open the local Vite URL (default port 4173).
+Then open the local Vite URL (default port 5173).
 
 ## Contributing
-Feel free to open issues or submit pull requests with improvements or bug fixes.
+Feel free to open issues or submit pull requests with improvements or bug fixes. PRs are validated with the
+GitHub Actions workflow in `.github/workflows/pr-structure-check.yml`, which runs backend tests
+(`poetry run python -m unittest discover -s tests`) and frontend checks/tests/build
+(`npm run check`, `npm test -- --run`, `npm run build`).
 
 ## License
 This repository is available for use without limitations.

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -154,6 +154,21 @@ class ApiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn("outside GPX time range", response.json()["detail"])
 
+    def test_trim_by_video_rejects_reversed_times(self) -> None:
+        files = {
+            "gpx_file": ("track.gpx", _build_gpx(), "application/gpx+xml"),
+        }
+        data = {
+            "start_time": "2024-01-01T00:00:20Z",
+            "end_time": "2024-01-01T00:00:10Z",
+            "duration_seconds": "10",
+        }
+
+        response = self.client.post("/api/v1/gpx/trim-by-video", files=files, data=data)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["detail"], "start_time must be before end_time")
+
     def test_trim_by_videos_success(self) -> None:
         files = {
             "gpx_file": ("track.gpx", _build_gpx(), "application/gpx+xml"),
@@ -209,6 +224,19 @@ class ApiTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()["detail"], "Clip 1 timestamps fall outside GPX time range")
+
+    def test_trim_by_videos_rejects_invalid_json(self) -> None:
+        files = {
+            "gpx_file": ("track.gpx", _build_gpx(), "application/gpx+xml"),
+        }
+        data = {
+            "clips_json": "{not valid json}",
+        }
+
+        response = self.client.post("/api/v1/gpx/trim-by-videos", files=files, data=data)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["detail"], "clips_json must be valid JSON")
 
     def test_map_animation_success(self) -> None:
         files = {


### PR DESCRIPTION
### Motivation
- Preserve and extend test coverage after the refactor so request parsing/validation behaviour remains verified.
- Ensure PR checks run the current frontend automated tests in CI as well as the backend test discovery used by the project.
- Refresh README content so examples, install/run commands, and CI/test references match the refactored layout and toolchain.

### Description
- Added focused backend API tests in `backend/tests/test_api.py` to cover validation paths: a `trim-by-video` case for reversed timestamps and a `trim-by-videos` case for malformed `clips_json` payloads.
- Updated the PR GitHub Actions workflow `.github/workflows/pr-structure-check.yml` to keep backend unit test discovery and to run frontend automated tests (`npm test -- --run`) in addition to type/check and build steps.
- Updated `README.md` content (kept the exact section ordering) to reflect current tooling and commands: Poetry-managed backend install, frontend `npm ci`, API request examples for multi-clip trimming and telemetry endpoints, and the local Vite port.
- No production code, API contracts, endpoints, frontend behavior, output formats, or user flows were changed.

### Testing
- Ran frontend automated tests and checks: `cd frontend && npm test -- --run && npm run check && npm run build` and all frontend tests/checks succeeded (Vitest: 15 tests passed; `svelte-check` found 0 issues; `vite build` succeeded).
- Attempted backend tests with the local environment using `cd backend && poetry run python -m unittest discover -s tests`, but test collection failed in this container due to missing Poetry-installed dependencies (`fastapi`, `PIL`, `numpy`) that are expected to be installed by `poetry install` in CI; the workflow will perform the install step before running tests.
- Updated unit tests (files modified: `backend/tests/test_api.py`) and updated CI workflow (file modified: `.github/workflows/pr-structure-check.yml`) and README (`README.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea809ea9ac83278242c5c87223c2cc)