### PR TITLE
Refactor API route internals and frontend workflow utilities

### DIFF
--- a/backend/src/gpx_helper/api/routes/animation.py
+++ b/backend/src/gpx_helper/api/routes/animation.py
@@ -6,6 +6,7 @@ import tempfile
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from fastapi.responses import JSONResponse, StreamingResponse
 
+from gpx_helper.api.utils.exceptions import as_bad_request
 from gpx_helper.api.utils.responses import stream_payload
 from gpx_helper.api.utils.uploads import validate_upload, write_upload_to_file
 from gpx_helper.api.utils.validation import (
@@ -85,13 +86,16 @@ def estimate_map_animation(
 
     with tempfile.NamedTemporaryFile(suffix=".gpx") as gpx_input:
         write_upload_to_file(gpx_file, gpx_input, "GPX")
-        try:
-            lats, lons = load_gpx_points(gpx_input.name)
-            estimated_seconds = estimate_animation_seconds(
-                lats, lons, width_px, height_px, duration_seconds, fps=fps
-            )
-        except Exception as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        lats, lons = as_bad_request(load_gpx_points, gpx_input.name)
+        estimated_seconds = as_bad_request(
+            estimate_animation_seconds,
+            lats,
+            lons,
+            width_px,
+            height_px,
+            duration_seconds,
+            fps=fps,
+        )
 
     return JSONResponse({"estimated_seconds": round(float(estimated_seconds), 2)})
 
@@ -133,37 +137,39 @@ def animate_gpx_route(
     ) as video_output:
         write_upload_to_file(gpx_file, gpx_input, "GPX")
 
-        try:
-            lats, lons = load_gpx_points(gpx_input.name)
-            xs, ys = latlon_to_web_mercator(lats, lons)
-            xs, ys, frame_indices, total_frames, fps = prepare_animation_series(
-                xs, ys, duration_seconds, fps=fps
-            )
-            create_animation(
-                xs,
-                ys,
-                frame_indices,
-                total_frames,
-                fps,
-                width_px,
-                height_px,
-                video_output.name,
-                min_lat=min(lats),
-                max_lat=max(lats),
-                min_lon=min(lons),
-                max_lon=max(lons),
-                marker_color=marker_color,
-                animated_line_color=trail_color,
-                full_line_color=full_trail_color,
-                full_line_opacity=full_trail_opacity,
-                line_width=line_width,
-                animated_line_opacity=line_opacity,
-                marker_size=marker_size,
-                tile_template=tile_template,
-                tile_subdomains=tile_subdomains,
-            )
-        except Exception as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        lats, lons = as_bad_request(load_gpx_points, gpx_input.name)
+        xs, ys = as_bad_request(latlon_to_web_mercator, lats, lons)
+        xs, ys, frame_indices, total_frames, fps = as_bad_request(
+            prepare_animation_series,
+            xs,
+            ys,
+            duration_seconds,
+            fps=fps,
+        )
+        as_bad_request(
+            create_animation,
+            xs,
+            ys,
+            frame_indices,
+            total_frames,
+            fps,
+            width_px,
+            height_px,
+            video_output.name,
+            min_lat=min(lats),
+            max_lat=max(lats),
+            min_lon=min(lons),
+            max_lon=max(lons),
+            marker_color=marker_color,
+            animated_line_color=trail_color,
+            full_line_color=full_trail_color,
+            full_line_opacity=full_trail_opacity,
+            line_width=line_width,
+            animated_line_opacity=line_opacity,
+            marker_size=marker_size,
+            tile_template=tile_template,
+            tile_subdomains=tile_subdomains,
+        )
 
         video_output.seek(0)
         upload_name = os.path.basename(gpx_file.filename or "")

--- a/backend/src/gpx_helper/api/routes/telemetry.py
+++ b/backend/src/gpx_helper/api/routes/telemetry.py
@@ -6,6 +6,7 @@ import tempfile
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from fastapi.responses import JSONResponse, StreamingResponse
 
+from gpx_helper.api.utils.exceptions import as_bad_request
 from gpx_helper.api.utils.responses import stream_payload
 from gpx_helper.api.utils.uploads import validate_upload, write_upload_to_file
 from gpx_helper.api.utils.validation import parse_positive, validate_resolution_dims
@@ -52,14 +53,15 @@ def estimate_telemetry_video(
 
     with tempfile.NamedTemporaryFile(suffix=".gpx") as gpx_input:
         write_upload_to_file(gpx_file, gpx_input, "GPX")
-        try:
-            telemetry_points = load_gpx_telemetry(gpx_input.name)
-            ensure_telemetry_type_supported(telemetry_points, resolved_type)
-            estimated_seconds = estimate_telemetry_seconds(
-                duration_seconds, width_px, height_px, fps=fps
-            )
-        except Exception as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        telemetry_points = as_bad_request(load_gpx_telemetry, gpx_input.name)
+        as_bad_request(ensure_telemetry_type_supported, telemetry_points, resolved_type)
+        estimated_seconds = as_bad_request(
+            estimate_telemetry_seconds,
+            duration_seconds,
+            width_px,
+            height_px,
+            fps=fps,
+        )
 
     return JSONResponse({"estimated_seconds": round(float(estimated_seconds), 2)})
 
@@ -93,21 +95,19 @@ def render_telemetry_video(
         suffix=output_suffix
     ) as video_output:
         write_upload_to_file(gpx_file, gpx_input, "GPX")
-        try:
-            telemetry_points = load_gpx_telemetry(gpx_input.name)
-            ensure_telemetry_type_supported(telemetry_points, resolved_type)
-            create_telemetry_animation(
-                telemetry_points,
-                duration_seconds=duration_seconds,
-                fps=fps,
-                width_px=width_px,
-                height_px=height_px,
-                telemetry_type=resolved_type,
-                background_color=background_color,
-                output_path=video_output.name,
-            )
-        except Exception as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        telemetry_points = as_bad_request(load_gpx_telemetry, gpx_input.name)
+        as_bad_request(ensure_telemetry_type_supported, telemetry_points, resolved_type)
+        as_bad_request(
+            create_telemetry_animation,
+            telemetry_points,
+            duration_seconds=duration_seconds,
+            fps=fps,
+            width_px=width_px,
+            height_px=height_px,
+            telemetry_type=resolved_type,
+            background_color=background_color,
+            output_path=video_output.name,
+        )
 
         video_output.seek(0)
         upload_name = os.path.basename(gpx_file.filename or "")

--- a/backend/src/gpx_helper/api/routes/trim.py
+++ b/backend/src/gpx_helper/api/routes/trim.py
@@ -4,13 +4,13 @@ from io import BytesIO
 import tempfile
 import zipfile
 
-from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, File, Form, UploadFile
 from fastapi.responses import StreamingResponse
 
+from gpx_helper.api.utils.gpx import crop_file_by_time, ensure_within_bounds, get_time_bounds
 from gpx_helper.api.utils.responses import stream_gpx, stream_payload
 from gpx_helper.api.utils.uploads import validate_upload, write_upload_to_file
 from gpx_helper.api.utils.validation import parse_request_times, parse_video_clips_payload, parse_positive
-from gpx_helper.gpx_splitter import crop_gpx_by_time, get_gpx_time_range
 
 router = APIRouter()
 
@@ -28,10 +28,7 @@ def trim_by_time(
         suffix=".gpx"
     ) as output_file:
         write_upload_to_file(gpx_file, input_file, "GPX")
-        try:
-            crop_gpx_by_time(input_file.name, start_dt, end_dt, output_file.name)
-        except Exception as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        crop_file_by_time(input_file.name, start_dt, end_dt, output_file.name)
         output_file.seek(0)
         return stream_gpx(output_file.read(), "trimmed.gpx")
 
@@ -51,20 +48,15 @@ def trim_by_video(
         suffix=".gpx"
     ) as gpx_output:
         write_upload_to_file(gpx_file, gpx_input, "GPX")
-        try:
-            gpx_start, gpx_end = get_gpx_time_range(gpx_input.name)
-        except Exception as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-        if start_dt < gpx_start or end_dt > gpx_end:
-            raise HTTPException(
-                status_code=400,
-                detail="Video timestamps fall outside GPX time range",
-            )
-        try:
-            crop_gpx_by_time(gpx_input.name, start_dt, end_dt, gpx_output.name)
-        except Exception as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        gpx_start, gpx_end = get_time_bounds(gpx_input.name)
+        ensure_within_bounds(
+            start_dt,
+            end_dt,
+            gpx_start,
+            gpx_end,
+            "Video timestamps fall outside GPX time range",
+        )
+        crop_file_by_time(gpx_input.name, start_dt, end_dt, gpx_output.name)
 
         gpx_output.seek(0)
         return stream_gpx(gpx_output.read(), "trimmed.gpx")
@@ -80,27 +72,23 @@ def trim_by_videos(
 
     with tempfile.NamedTemporaryFile(suffix=".gpx") as gpx_input:
         write_upload_to_file(gpx_file, gpx_input, "GPX")
-        try:
-            gpx_start, gpx_end = get_gpx_time_range(gpx_input.name)
-        except Exception as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        gpx_start, gpx_end = get_time_bounds(gpx_input.name)
 
         zip_buffer = BytesIO()
         with zipfile.ZipFile(zip_buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
             for index, clip in enumerate(clips, start=1):
                 start_dt = clip["start_dt"]
                 end_dt = clip["end_dt"]
-                if start_dt < gpx_start or end_dt > gpx_end:
-                    raise HTTPException(
-                        status_code=400,
-                        detail=f"Clip {index} timestamps fall outside GPX time range",
-                    )
+                ensure_within_bounds(
+                    start_dt,
+                    end_dt,
+                    gpx_start,
+                    gpx_end,
+                    f"Clip {index} timestamps fall outside GPX time range",
+                )
 
                 with tempfile.NamedTemporaryFile(suffix=".gpx") as gpx_output:
-                    try:
-                        crop_gpx_by_time(gpx_input.name, start_dt, end_dt, gpx_output.name)
-                    except Exception as exc:
-                        raise HTTPException(status_code=400, detail=str(exc)) from exc
+                    crop_file_by_time(gpx_input.name, start_dt, end_dt, gpx_output.name)
 
                     gpx_output.seek(0)
                     archive.writestr(f"{index}.gpx", gpx_output.read())

--- a/backend/src/gpx_helper/api/utils/exceptions.py
+++ b/backend/src/gpx_helper/api/utils/exceptions.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import TypeVar
+
+from fastapi import HTTPException
+
+
+T = TypeVar("T")
+
+
+def as_bad_request(func, *args, **kwargs) -> T:
+    """Execute a callable and map unexpected errors to HTTP 400 responses."""
+    try:
+        return func(*args, **kwargs)
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/backend/src/gpx_helper/api/utils/gpx.py
+++ b/backend/src/gpx_helper/api/utils/gpx.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import HTTPException
+
+from gpx_helper.api.utils.exceptions import as_bad_request
+from gpx_helper.gpx_splitter import crop_gpx_by_time, get_gpx_time_range
+
+
+def get_time_bounds(gpx_path: str) -> tuple[datetime, datetime]:
+    """Read first/last GPX timestamps from file."""
+    return as_bad_request(get_gpx_time_range, gpx_path)
+
+
+def crop_file_by_time(gpx_input_path: str, start_dt: datetime, end_dt: datetime, output_path: str) -> None:
+    """Crop GPX points by UTC datetime range into an output file."""
+    as_bad_request(crop_gpx_by_time, gpx_input_path, start_dt, end_dt, output_path)
+
+
+def ensure_within_bounds(start_dt: datetime, end_dt: datetime, bound_start: datetime, bound_end: datetime, detail: str) -> None:
+    if start_dt < bound_start or end_dt > bound_end:
+        raise HTTPException(status_code=400, detail=detail)

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -6,13 +6,12 @@
   import TaskSelector from './components/TaskSelector.svelte';
   import TelemetryPage from './components/TelemetryPage.svelte';
   import TrimPage from './components/TrimPage.svelte';
-  import { parseGpxDurationFromText, parseGpxTimeRangeFromText } from './gpx-metadata';
-  import { loadEmbeddedVideoStart } from './video-metadata';
+  import { DEFAULT_API_BASE, MAP_TILE_OPTIONS, PAGE_DESCRIPTIONS, PAGES, TASKS, TELEMETRY_TYPE_OPTIONS } from './constants';
   import { cloneFormData, deriveMp4Filename, parseError, requestEta, requestFile } from './utils/api';
-  import { readFileText, loadVideoDuration } from './utils/files';
-  import { formatDurationLabel, formatUtcLabel, toIsoString, toLocalDateTimeValue } from './utils/time';
+  import { buildMapAnimationFormData, buildTelemetryFormData, buildTrimByTimeFormData, buildTrimByVideosFormData } from './utils/formData';
+  import { formatDurationLabel, toIsoString, toLocalDateTimeValue } from './utils/time';
+  import { buildVideoClip, deriveVideoTimes, ensureRangeFitsGpx, ensureVideosFitGpx, parseGpxDuration } from './utils/workflows';
 
-  const DEFAULT_API_BASE = (import.meta.env.VITE_API_BASE ?? 'http://localhost:8000').replace(/\/$/, '');
   let apiBase = DEFAULT_API_BASE;
 
   let trimByTime = { startLocal: '', endLocal: '', gpxFile: null, videoFile: null, status: 'idle', error: '', downloadUrl: '', filename: '', message: '' };
@@ -20,35 +19,11 @@
   let mapAnimation = { gpxFile: null, durationSeconds: 45, fps: 30, resolutionWidth: 1024, resolutionHeight: 1024, tileType: '', markerColor: '#0ea5e9', trailColor: '#0ea5e9', fullTrailColor: '#111827', fullTrailOpacity: 0.8, markerSize: 6, lineWidth: 2.5, lineOpacity: 1, status: 'idle', error: '', downloadUrl: '', filename: '', message: '' };
   let telemetryVideo = { gpxFile: null, durationSeconds: 4, fps: 30, resolutionWidth: 1024, resolutionHeight: 1024, telemetryType: 'elevation_value', backgroundColor: 'transparent', status: 'idle', error: '', downloadUrl: '', filename: '', message: '' };
 
-  const mapTileOptions = [
-    { value: '', label: 'Backend default (MAP_TILE_URL_TEMPLATE)' },
-    { value: 'osm', label: 'OpenStreetMap (Standard)' },
-    { value: 'cyclosm', label: 'CyclOSM' },
-    { value: 'opentopomap', label: 'OpenTopoMap (Topo)' }
-  ];
-  const telemetryTypeOptions = [
-    { value: 'elevation_value', label: 'Elevation value' },
-    { value: 'speed', label: 'Speed' },
-    { value: 'heart_rate', label: 'Heart rate' },
-    { value: 'elevation_graph', label: 'Elevation graph' }
-  ];
-  const tasks = [
-    { id: 'trim', href: '#/trim', label: 'Trim GPX', description: 'Cut a track by timestamps or split it around recorded videos.' },
-    { id: 'animation', href: '#/animation', label: 'Create route animation', description: 'Render a map-based MP4 animation from a GPX route.' },
-    { id: 'telemetry', href: '#/telemetry', label: 'Generate telemetry video', description: 'Export an MP4 overlay with speed, elevation, or graph data.' }
-  ];
-  const pages = [
-    { id: 'trim', href: '#/trim', label: 'Trim GPX' },
-    { id: 'animation', href: '#/animation', label: 'Route animation' },
-    { id: 'telemetry', href: '#/telemetry', label: 'Telemetry video' },
-    { id: 'about', href: '#/about', label: 'About' }
-  ];
-  const pageDescriptions = {
-    trim: 'Trim tracks by exact times or split them from video metadata.',
-    animation: 'Render a clean MP4 route animation from a GPX track.',
-    telemetry: 'Create telemetry-only videos for overlays and compositing.',
-    about: 'A quick overview of the tools available in GPX Helper.'
-  };
+  const mapTileOptions = MAP_TILE_OPTIONS;
+  const telemetryTypeOptions = TELEMETRY_TYPE_OPTIONS;
+  const tasks = TASKS;
+  const pages = PAGES;
+  const pageDescriptions = PAGE_DESCRIPTIONS;
   const defaultPage = pages[0].id;
 
   let activeRequestLabel = '';
@@ -97,64 +72,6 @@
     estimatedSeconds = null;
   }
 
-  async function deriveVideoTimes(file) {
-    const [durationSeconds, start] = await Promise.all([loadVideoDuration(file), loadEmbeddedVideoStart(file)]);
-    const end = new Date(start.getTime() + durationSeconds * 1000);
-    return { durationSeconds, start, end };
-  }
-
-  async function buildVideoClip(file, index) {
-    const { durationSeconds, start, end } = await deriveVideoTimes(file);
-    return {
-      id: `${file.name}-${file.size}-${index}`,
-      name: file.name,
-      durationSeconds,
-      startIso: start.toISOString(),
-      endIso: end.toISOString(),
-      startLocal: toLocalDateTimeValue(start),
-      endLocal: toLocalDateTimeValue(end)
-    };
-  }
-
-  async function parseGpxDuration(file) {
-    if (!file) return null;
-    const text = await readFileText(file);
-    return parseGpxDurationFromText(text);
-  }
-
-  async function parseGpxTimeRange(file) {
-    if (!file) return null;
-    const text = await readFileText(file);
-    return parseGpxTimeRangeFromText(text);
-  }
-
-  function buildVideoRangeError(label, start, end, gpxRange) {
-    return `${label} spans ${formatUtcLabel(start)} to ${formatUtcLabel(end)}, but the GPX track only covers ${formatUtcLabel(gpxRange.start)} to ${formatUtcLabel(gpxRange.end)}.`;
-  }
-
-  async function ensureRangeFitsGpx(label, start, end, gpxFile) {
-    if (!gpxFile) return;
-    const gpxRange = await parseGpxTimeRange(gpxFile);
-    if (!gpxRange) throw new Error('The GPX file does not contain readable timestamps.');
-    if (start < gpxRange.start || end > gpxRange.end) throw new Error(buildVideoRangeError(label, start, end, gpxRange));
-  }
-
-  async function ensureVideosFitGpx(clips, gpxFile) {
-    if (!clips.length || !gpxFile) return;
-    const gpxRange = await parseGpxTimeRange(gpxFile);
-    if (!gpxRange) throw new Error('The GPX file does not contain readable timestamps.');
-
-    const mismatchedClip = clips.find((clip) => {
-      const start = new Date(clip.startIso);
-      const end = new Date(clip.endIso);
-      return start < gpxRange.start || end > gpxRange.end;
-    });
-
-    if (mismatchedClip) {
-      throw new Error(buildVideoRangeError(`Video "${mismatchedClip.name}"`, new Date(mismatchedClip.startIso), new Date(mismatchedClip.endIso), gpxRange));
-    }
-  }
-
   async function submitTrimByTime() {
     if (trimByTime.downloadUrl) URL.revokeObjectURL(trimByTime.downloadUrl);
     startRequest('Trimming GPX by time...');
@@ -169,10 +86,7 @@
       if (startDate >= endDate) throw new Error('Start time must be before end time.');
       await ensureRangeFitsGpx('Selected trim range', startDate, endDate, trimByTime.gpxFile);
 
-      const formData = new FormData();
-      formData.append('gpx_file', trimByTime.gpxFile);
-      formData.append('start_time', startIso);
-      formData.append('end_time', endIso);
+      const formData = buildTrimByTimeFormData(trimByTime.gpxFile, startIso, endIso);
 
       const { blob, filename } = await requestFile(apiBase, '/api/v1/gpx/trim-by-time', formData, 'trimmed.gpx');
       const downloadUrl = URL.createObjectURL(blob);
@@ -194,9 +108,7 @@
       if (!trimByVideos.clips.length) throw new Error('Add at least one video file.');
       await ensureVideosFitGpx(trimByVideos.clips, trimByVideos.gpxFile);
 
-      const formData = new FormData();
-      formData.append('gpx_file', trimByVideos.gpxFile);
-      formData.append('clips_json', JSON.stringify(trimByVideos.clips.map((clip) => ({ start_time: clip.startIso, end_time: clip.endIso, duration_seconds: clip.durationSeconds }))));
+      const formData = buildTrimByVideosFormData(trimByVideos.gpxFile, trimByVideos.clips);
 
       const { blob, filename } = await requestFile(apiBase, '/api/v1/gpx/trim-by-videos', formData, 'trimmed-gpx-files.zip');
       const downloadUrl = URL.createObjectURL(blob);
@@ -225,19 +137,7 @@
       if (mapAnimation.resolutionWidth <= 0 || mapAnimation.resolutionHeight <= 0) throw new Error('Resolution must be greater than zero.');
       const resolutionLabel = `${mapAnimation.resolutionWidth}x${mapAnimation.resolutionHeight}`;
 
-      const formData = new FormData();
-      formData.append('gpx_file', mapAnimation.gpxFile);
-      formData.append('duration_seconds', String(mapAnimation.durationSeconds));
-      formData.append('fps', String(mapAnimation.fps));
-      formData.append('resolution', resolutionLabel);
-      formData.append('marker_color', mapAnimation.markerColor);
-      formData.append('trail_color', mapAnimation.trailColor);
-      formData.append('full_trail_color', mapAnimation.fullTrailColor);
-      formData.append('full_trail_opacity', String(mapAnimation.fullTrailOpacity));
-      formData.append('marker_size', String(mapAnimation.markerSize));
-      formData.append('line_width', String(mapAnimation.lineWidth));
-      formData.append('line_opacity', String(mapAnimation.lineOpacity));
-      if (mapAnimation.tileType) formData.append('tile_type', mapAnimation.tileType);
+      const formData = buildMapAnimationFormData(mapAnimation, resolutionLabel);
 
       requestEta(apiBase, '/api/v1/gpx/map-animate/estimate', cloneFormData(formData)).then((eta) => {
         estimatedSeconds = eta;
@@ -274,13 +174,7 @@
       const resolutionLabel = `${telemetryVideo.resolutionWidth}x${telemetryVideo.resolutionHeight}`;
       const backgroundColor = telemetryVideo.backgroundColor?.trim() || 'transparent';
 
-      const formData = new FormData();
-      formData.append('gpx_file', telemetryVideo.gpxFile);
-      formData.append('duration_seconds', String(telemetryVideo.durationSeconds));
-      formData.append('fps', String(telemetryVideo.fps));
-      formData.append('resolution', resolutionLabel);
-      formData.append('telemetry_type', telemetryVideo.telemetryType);
-      formData.append('background_color', backgroundColor);
+      const formData = buildTelemetryFormData(telemetryVideo, resolutionLabel, backgroundColor);
 
       requestEta(apiBase, '/api/v1/gpx/telemetry-video/estimate', cloneFormData(formData)).then((eta) => {
         estimatedSeconds = eta;

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,0 +1,35 @@
+export const DEFAULT_API_BASE = (import.meta.env.VITE_API_BASE ?? 'http://localhost:8000').replace(/\/$/, '');
+
+export const MAP_TILE_OPTIONS = [
+  { value: '', label: 'Backend default (MAP_TILE_URL_TEMPLATE)' },
+  { value: 'osm', label: 'OpenStreetMap (Standard)' },
+  { value: 'cyclosm', label: 'CyclOSM' },
+  { value: 'opentopomap', label: 'OpenTopoMap (Topo)' }
+];
+
+export const TELEMETRY_TYPE_OPTIONS = [
+  { value: 'elevation_value', label: 'Elevation value' },
+  { value: 'speed', label: 'Speed' },
+  { value: 'heart_rate', label: 'Heart rate' },
+  { value: 'elevation_graph', label: 'Elevation graph' }
+];
+
+export const TASKS = [
+  { id: 'trim', href: '#/trim', label: 'Trim GPX', description: 'Cut a track by timestamps or split it around recorded videos.' },
+  { id: 'animation', href: '#/animation', label: 'Create route animation', description: 'Render a map-based MP4 animation from a GPX route.' },
+  { id: 'telemetry', href: '#/telemetry', label: 'Generate telemetry video', description: 'Export an MP4 overlay with speed, elevation, or graph data.' }
+];
+
+export const PAGES = [
+  { id: 'trim', href: '#/trim', label: 'Trim GPX' },
+  { id: 'animation', href: '#/animation', label: 'Route animation' },
+  { id: 'telemetry', href: '#/telemetry', label: 'Telemetry video' },
+  { id: 'about', href: '#/about', label: 'About' }
+];
+
+export const PAGE_DESCRIPTIONS = {
+  trim: 'Trim tracks by exact times or split them from video metadata.',
+  animation: 'Render a clean MP4 route animation from a GPX track.',
+  telemetry: 'Create telemetry-only videos for overlays and compositing.',
+  about: 'A quick overview of the tools available in GPX Helper.'
+};

--- a/frontend/src/utils/formData.js
+++ b/frontend/src/utils/formData.js
@@ -1,0 +1,45 @@
+export function buildTrimByTimeFormData(gpxFile, startIso, endIso) {
+  const formData = new FormData();
+  formData.append('gpx_file', gpxFile);
+  formData.append('start_time', startIso);
+  formData.append('end_time', endIso);
+  return formData;
+}
+
+export function buildTrimByVideosFormData(gpxFile, clips) {
+  const formData = new FormData();
+  formData.append('gpx_file', gpxFile);
+  formData.append(
+    'clips_json',
+    JSON.stringify(clips.map((clip) => ({ start_time: clip.startIso, end_time: clip.endIso, duration_seconds: clip.durationSeconds })))
+  );
+  return formData;
+}
+
+export function buildMapAnimationFormData(mapAnimation, resolutionLabel) {
+  const formData = new FormData();
+  formData.append('gpx_file', mapAnimation.gpxFile);
+  formData.append('duration_seconds', String(mapAnimation.durationSeconds));
+  formData.append('fps', String(mapAnimation.fps));
+  formData.append('resolution', resolutionLabel);
+  formData.append('marker_color', mapAnimation.markerColor);
+  formData.append('trail_color', mapAnimation.trailColor);
+  formData.append('full_trail_color', mapAnimation.fullTrailColor);
+  formData.append('full_trail_opacity', String(mapAnimation.fullTrailOpacity));
+  formData.append('marker_size', String(mapAnimation.markerSize));
+  formData.append('line_width', String(mapAnimation.lineWidth));
+  formData.append('line_opacity', String(mapAnimation.lineOpacity));
+  if (mapAnimation.tileType) formData.append('tile_type', mapAnimation.tileType);
+  return formData;
+}
+
+export function buildTelemetryFormData(telemetryVideo, resolutionLabel, backgroundColor) {
+  const formData = new FormData();
+  formData.append('gpx_file', telemetryVideo.gpxFile);
+  formData.append('duration_seconds', String(telemetryVideo.durationSeconds));
+  formData.append('fps', String(telemetryVideo.fps));
+  formData.append('resolution', resolutionLabel);
+  formData.append('telemetry_type', telemetryVideo.telemetryType);
+  formData.append('background_color', backgroundColor);
+  return formData;
+}

--- a/frontend/src/utils/workflows.js
+++ b/frontend/src/utils/workflows.js
@@ -1,0 +1,69 @@
+import { parseGpxDurationFromText, parseGpxTimeRangeFromText } from '../gpx-metadata';
+import { loadEmbeddedVideoStart } from '../video-metadata';
+import { readFileText, loadVideoDuration } from './files';
+import { formatUtcLabel, toLocalDateTimeValue } from './time';
+
+export async function deriveVideoTimes(file) {
+  const [durationSeconds, start] = await Promise.all([loadVideoDuration(file), loadEmbeddedVideoStart(file)]);
+  const end = new Date(start.getTime() + durationSeconds * 1000);
+  return { durationSeconds, start, end };
+}
+
+export async function buildVideoClip(file, index) {
+  const { durationSeconds, start, end } = await deriveVideoTimes(file);
+  return {
+    id: `${file.name}-${file.size}-${index}`,
+    name: file.name,
+    durationSeconds,
+    startIso: start.toISOString(),
+    endIso: end.toISOString(),
+    startLocal: toLocalDateTimeValue(start),
+    endLocal: toLocalDateTimeValue(end)
+  };
+}
+
+export async function parseGpxDuration(file) {
+  if (!file) return null;
+  const text = await readFileText(file);
+  return parseGpxDurationFromText(text);
+}
+
+export async function parseGpxTimeRange(file) {
+  if (!file) return null;
+  const text = await readFileText(file);
+  return parseGpxTimeRangeFromText(text);
+}
+
+function buildVideoRangeError(label, start, end, gpxRange) {
+  return `${label} spans ${formatUtcLabel(start)} to ${formatUtcLabel(end)}, but the GPX track only covers ${formatUtcLabel(gpxRange.start)} to ${formatUtcLabel(gpxRange.end)}.`;
+}
+
+export async function ensureRangeFitsGpx(label, start, end, gpxFile) {
+  if (!gpxFile) return;
+  const gpxRange = await parseGpxTimeRange(gpxFile);
+  if (!gpxRange) throw new Error('The GPX file does not contain readable timestamps.');
+  if (start < gpxRange.start || end > gpxRange.end) throw new Error(buildVideoRangeError(label, start, end, gpxRange));
+}
+
+export async function ensureVideosFitGpx(clips, gpxFile) {
+  if (!clips.length || !gpxFile) return;
+  const gpxRange = await parseGpxTimeRange(gpxFile);
+  if (!gpxRange) throw new Error('The GPX file does not contain readable timestamps.');
+
+  const mismatchedClip = clips.find((clip) => {
+    const start = new Date(clip.startIso);
+    const end = new Date(clip.endIso);
+    return start < gpxRange.start || end > gpxRange.end;
+  });
+
+  if (mismatchedClip) {
+    throw new Error(
+      buildVideoRangeError(
+        `Video "${mismatchedClip.name}"`,
+        new Date(mismatchedClip.startIso),
+        new Date(mismatchedClip.endIso),
+        gpxRange
+      )
+    );
+  }
+}


### PR DESCRIPTION
### Motivation
- Reduce duplication and improve separation of concerns in API route handlers by moving GPX processing and exception-mapping into focused utilities.
- Make the frontend app orchestration easier to maintain by extracting repeated constants, FormData construction, and workflow logic from `App.svelte`.
- Keep all public behavior, API endpoints, request/response shapes, and UI flows unchanged while improving readability and testability.

### Description
- Added `gpx_helper.api.utils.exceptions.as_bad_request` to centralize mapping unexpected errors to HTTP 400 responses and used it from server routes.
- Added `gpx_helper.api.utils.gpx` with `get_time_bounds`, `crop_file_by_time`, and `ensure_within_bounds` to encapsulate GPX time-range reading and cropping logic.
- Updated backend route handlers in `api/routes/trim.py`, `api/routes/animation.py`, and `api/routes/telemetry.py` to call the new utilities and to remove repeated `try/except` blocks while preserving original validation messages and outputs.
- Extracted frontend constants to `frontend/src/constants.js` and moved repeated FormData builders into `frontend/src/utils/formData.js` to standardize request payload construction.
- Extracted client-side workflow helpers (video metadata handling, GPX time parsing and range checks) to `frontend/src/utils/workflows.js` and updated `frontend/src/App.svelte` to import and use the new modules so components remain focused.
- Files created: `backend/src/gpx_helper/api/utils/exceptions.py`, `backend/src/gpx_helper/api/utils/gpx.py`, `frontend/src/constants.js`, `frontend/src/utils/formData.js`, and `frontend/src/utils/workflows.js`.

### Testing
- Ran `python -m compileall backend/src/gpx_helper` to validate backend modules compiled successfully.
- Ran backend tests with `cd backend && poetry run pytest`, which failed to collect due to missing runtime dependencies in the environment (`fastapi`, `PIL`, `numpy`); this is an environment/dependency issue, not a code-behavior regression.
- Ran frontend checks and builds: `cd frontend && npm run check` succeeded with `svelte-check` reporting 0 errors; `cd frontend && npm test` succeeded with all tests passing; `cd frontend && npm run build` completed successfully and produced a production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb7776a588327b845775b4efbb483)